### PR TITLE
Fix flutter gradle plugin usage

### DIFF
--- a/android/settings.gradle
+++ b/android/settings.gradle
@@ -1,11 +1,25 @@
+pluginManagement {
+    def flutterSdkPath = {
+        def properties = new Properties()
+        file("local.properties").withInputStream { properties.load(it) }
+        def path = properties.getProperty("flutter.sdk")
+        assert path != null : "flutter.sdk not set in local.properties"
+        return path
+    }.call()
+
+    includeBuild("$flutterSdkPath/packages/flutter_tools/gradle")
+
+    repositories {
+        google()
+        mavenCentral()
+        gradlePluginPortal()
+    }
+}
+
+plugins {
+    id "dev.flutter.flutter-plugin-loader" version "1.0.0"
+    id "com.android.application" version "8.3.1" apply false
+    id "org.jetbrains.kotlin.android" version "2.0.0" apply false
+}
+
 include ':app'
-
-def localPropertiesFile = new File(rootProject.projectDir, "local.properties")
-def properties = new Properties()
-
-assert localPropertiesFile.exists()
-localPropertiesFile.withReader("UTF-8") { reader -> properties.load(reader) }
-
-def flutterSdkPath = properties.getProperty("flutter.sdk")
-assert flutterSdkPath != null, "flutter.sdk not set in local.properties"
-apply from: "$flutterSdkPath/packages/flutter_tools/gradle/app_plugin_loader.gradle"


### PR DESCRIPTION
## Summary
- migrate plugin loader in `android/settings.gradle` to declarative usage

## Testing
- `./gradlew --version`
- `./gradlew -p android :app:tasks` *(fails: `/workspace/remontada/android/local.properties (No such file or directory)`)*

------
https://chatgpt.com/codex/tasks/task_b_68502457d994832baff9d343bfaf8712