### PR TITLE
Fix TabBarTheme type for Flutter update

### DIFF
--- a/lib/core/theme/dark_theme.dart
+++ b/lib/core/theme/dark_theme.dart
@@ -209,7 +209,7 @@ class DarkTheme {
       bottomSheetTheme: BottomSheetThemeData(),
 
       //* Tab Bar Theme
-      tabBarTheme: TabBarTheme(),
+      tabBarTheme: const TabBarThemeData(),
 
       //* ElevatedButtonThemeData
       elevatedButtonTheme: ElevatedButtonThemeData(),


### PR DESCRIPTION
## Summary
- update dark theme to use `TabBarThemeData`

## Testing
- `dart --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_68502a1a6648832b85e8e6230873deb3