### PR TITLE
Enable Android core library desugaring

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -37,6 +37,7 @@ android {
     compileOptions {
         sourceCompatibility JavaVersion.VERSION_17
         targetCompatibility JavaVersion.VERSION_17
+        coreLibraryDesugaringEnabled true
     }
 
     kotlinOptions {
@@ -88,6 +89,7 @@ flutter {
 }
 
 dependencies {
-    
+
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
+    coreLibraryDesugaring 'com.android.tools:desugar_jdk_libs:2.0.3'
 }


### PR DESCRIPTION
## Summary
- enable coreLibraryDesugaring in compile options
- add desugar_jdk_libs dependency for Android build

## Testing
- `./gradlew -p android tasks` *(fails: `/workspace/remontada/android/local.properties (No such file or directory)`)*

------
https://chatgpt.com/codex/tasks/task_b_68502d864904832b8f8a378851a90b77