### PR TITLE
Add Challenges tab

### DIFF
--- a/assets/icons/active_trophy.svg
+++ b/assets/icons/active_trophy.svg
@@ -1,0 +1,3 @@
+<svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M7 4V2h10v2h4v4c0 3.31-2.69 6-6 6v2h3v2H6v-2h3v-2c-3.31 0-6-2.69-6-6V4h4z" fill="currentColor"/>
+</svg>

--- a/assets/icons/trophy.svg
+++ b/assets/icons/trophy.svg
@@ -1,0 +1,3 @@
+<svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M7 4V2h10v2h4v4c0 3.31-2.69 6-6 6v2h3v2H6v-2h3v-2c-3.31 0-6-2.69-6-6V4h4z" fill="currentColor"/>
+</svg>

--- a/assets/translations/ar-EG.json
+++ b/assets/translations/ar-EG.json
@@ -154,6 +154,7 @@
   "navBar": {
   "home": "الرئيسية",
   "my_matches": "مبارياتي",
+  "challenges": "التحديات",
   "notifications": "الاشعارات",
   "more": "المزيد"
   

--- a/assets/translations/en-US.json
+++ b/assets/translations/en-US.json
@@ -142,6 +142,7 @@
   "navBar": {
     "workSpace": "Work Space",
     "approval": "Approvals",
+    "challenges": "Challenges",
     "notifications": "Notifications",
     "settings": "Settings"
   },

--- a/lib/core/Router/Router.dart
+++ b/lib/core/Router/Router.dart
@@ -7,6 +7,7 @@ import 'package:remontada/features/layout/presentation/screens/layout_screen.dar
 import 'package:remontada/features/matchdetails/presentaion/screens/matchDetails_screen.dart';
 import 'package:remontada/features/more/domain/contact_request.dart';
 import 'package:remontada/features/my_matches/presentation/screens/create_match_screen.dart';
+import 'package:remontada/features/challenges/presentation/screens/challenges_screen.dart';
 import 'package:remontada/features/player_details/presentation/screens/player_details.dart';
 import 'package:remontada/features/profile/presentation/screens/edit_profile.screen.dart';
 import 'package:remontada/features/splash/cubit/splash_cubit.dart';
@@ -45,6 +46,7 @@ class Routes {
   static const String webPage = "/webPage";
   static const String CreateMatchScreen = "/CreateMatchScreen";
   static const String PlayersScreenSupervisor = "/PlayersScreenSupervisor";
+  static const String challengesScreen = "/ChallengesScreen";
   static const String UpdateAppScreen = "/UpdateAppScreen";
 }
 
@@ -217,6 +219,13 @@ class RouteGenerator {
               // id: routeSettings.arguments as String?,
               // uri: routeSettings.arguments as String,
             );
+          },
+        );
+      case Routes.challengesScreen:
+        return CupertinoPageRoute(
+          settings: routeSettings,
+          builder: (_) {
+            return const ChallengesScreen();
           },
         );
       // case Routes.SplashScreen:

--- a/lib/core/app_strings/locale_keys.dart
+++ b/lib/core/app_strings/locale_keys.dart
@@ -32,6 +32,7 @@ abstract class LocaleKeys {
   // start nav
   static const home_nav = 'navBar.home';
   static const my_matches_nav = 'navBar.my_matches';
+  static const challenges_nav = 'navBar.challenges';
   static const notifications_nav = 'navBar.notifications';
   static const more_nav = 'navBar.more';
   //end nav

--- a/lib/core/resources/gen/assets.gen.dart
+++ b/lib/core/resources/gen/assets.gen.dart
@@ -85,11 +85,17 @@ class $AssetsIconsGen {
   /// File path: assets/icons/active_notify.svg
   String get active_notify => 'assets/icons/active_notify.svg';
 
+  /// File path: assets/icons/active_trophy.svg
+  String get active_trophy => 'assets/icons/active_trophy.svg';
+
   /// File path: ssets/icons/active_more.svg
   String get active_more => 'assets/icons/active_more.svg';
 
   /// File path: assets/icons/notify.svg
   String get notify => 'assets/icons/notify.svg';
+
+  /// File path: assets/icons/trophy.svg
+  String get trophy => 'assets/icons/trophy.svg';
 
   /// File path: ssets/icons/arena.svg
   String get arena => 'assets/icons/arena.svg';

--- a/lib/features/challenges/presentation/screens/challenges_screen.dart
+++ b/lib/features/challenges/presentation/screens/challenges_screen.dart
@@ -1,0 +1,22 @@
+import 'package:flutter/material.dart';
+import 'package:remontada/shared/widgets/customtext.dart';
+
+/// Placeholder screen shown for the upcoming Challenges feature.
+class ChallengesScreen extends StatelessWidget {
+  const ChallengesScreen({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: const Text('التحديات')),
+      body: const Center(
+        child: CustomText(
+          'هذه الصفحة قيد التطوير',
+          fontSize: 18,
+          weight: FontWeight.w600,
+          color: Colors.grey,
+        ),
+      ),
+    );
+  }
+}

--- a/lib/features/layout/cubit/layout_cubit.dart
+++ b/lib/features/layout/cubit/layout_cubit.dart
@@ -12,8 +12,12 @@ class LayoutCubit extends Cubit<LayoutStates> {
   LayoutRepository layoutRepository = LayoutRepository(locator<DioService>());
   late TabController tabController;
 
-  initTabBar(vsync, [int index = 0]) {
-    tabController = TabController(length: 4, vsync: vsync, initialIndex: index);
+  /// Initializes the bottom navigation tab controller.
+  ///
+  /// [vsync] provides the ticker provider for animations.
+  /// [index] sets the initial tab index.
+  void initTabBar(vsync, [int index = 0]) {
+    tabController = TabController(length: 5, vsync: vsync, initialIndex: index);
   }
 
   void changeTab(int tab) {
@@ -33,9 +37,6 @@ class LayoutCubit extends Cubit<LayoutStates> {
         break;
       case 4:
         tabController.animateTo(4);
-        break;
-      case 5:
-        tabController.animateTo(5);
         break;
       default:
     }

--- a/lib/features/layout/presentation/screens/layout_screen.dart
+++ b/lib/features/layout/presentation/screens/layout_screen.dart
@@ -8,6 +8,7 @@ import 'package:remontada/core/utils/utils.dart';
 import 'package:remontada/features/more/presentation/screens/more_screen.dart';
 import 'package:remontada/features/my_matches/presentation/screens/mymatches_screen.dart';
 import 'package:remontada/features/notifications/presentation/screens/notification_Screen.dart';
+import 'package:remontada/features/challenges/presentation/screens/challenges_screen.dart';
 import 'package:remontada/shared/widgets/button_widget.dart';
 import 'package:remontada/shared/widgets/customtext.dart';
 
@@ -99,6 +100,58 @@ class _LayoutScreenState extends State<LayoutScreen>
                         initialIndex: 0,
                         child: MyMatchesScreen(),
                       ),
+                Utils.token == ""
+                    ? Center(
+                        child: Padding(
+                          padding: const EdgeInsets.symmetric(horizontal: 15),
+                          child: Column(
+                            mainAxisAlignment: MainAxisAlignment.center,
+                            children: [
+                              SvgPicture.asset(
+                                Assets.icons.logo,
+                                // width: 100,
+                                // height: 70,
+                                color: context.primaryColor,
+                              ),
+                              20.ph,
+                              Row(
+                                children: [
+                                  Expanded(
+                                    child: ButtonWidget(
+                                      onTap: () => Navigator.pushNamed(
+                                        context,
+                                        Routes.LoginScreen,
+                                      ),
+                                      child: CustomText(
+                                        weight: FontWeight.w600,
+                                        fontSize: 16,
+                                        "تسجيل الدخول",
+                                        color: Colors.white,
+                                      ),
+                                    ),
+                                  ),
+                                  15.pw,
+                                  Expanded(
+                                    child: ButtonWidget(
+                                      onTap: () => Navigator.pushNamed(
+                                        context,
+                                        Routes.RegisterScreen,
+                                      ),
+                                      child: CustomText(
+                                        weight: FontWeight.w600,
+                                        fontSize: 16,
+                                        " انشاء حساب",
+                                        color: Colors.white,
+                                      ),
+                                    ),
+                                  )
+                                ],
+                              )
+                            ],
+                          ),
+                        ),
+                      )
+                    : const ChallengesScreen(),
                 Utils.token == ""
                     ? Center(
                         child: Padding(

--- a/lib/features/layout/presentation/widgets/widgets.dart
+++ b/lib/features/layout/presentation/widgets/widgets.dart
@@ -74,15 +74,21 @@ class _CustomBottomNavBarState extends State<CustomBottomNavBar> {
                 Assets.icons.myMatches_active,
               ),
               navBarItem(
+                Assets.icons.trophy,
+                LocaleKeys.challenges_nav.tr(),
+                2,
+                Assets.icons.active_trophy,
+              ),
+              navBarItem(
                 Assets.icons.notify,
                 LocaleKeys.notifications_nav.tr(),
-                2,
+                3,
                 Assets.icons.active_notify,
               ),
               navBarItem(
                 Assets.icons.more,
                 LocaleKeys.more_nav.tr(),
-                3,
+                4,
                 Assets.icons.active_more,
               ),
             ],

--- a/test/layout_cubit_test.dart
+++ b/test/layout_cubit_test.dart
@@ -1,0 +1,11 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:flutter/widgets.dart';
+import 'package:remontada/features/layout/cubit/layout_cubit.dart';
+
+void main() {
+  test('initTabBar sets up five tabs', () {
+    final cubit = LayoutCubit();
+    cubit.initTabBar(const TestVSync());
+    expect(cubit.tabController.length, 5);
+  });
+}


### PR DESCRIPTION
## Summary
- add new placeholder page for challenges
- include challenges tab in bottom navigation
- update navigation cubit and router for new page
- localize challenges strings
- add basic unit test for LayoutCubit

## Testing
- `flutter analyze` *(fails: 118 issues)*
- `flutter test` *(fails due to MissingPluginException)*

------
https://chatgpt.com/codex/tasks/task_b_687d17988e6c832cba75efa4da33b118