### PR TITLE
Update challenges tab icon

### DIFF
--- a/assets/icons/active_trophy.svg
+++ b/assets/icons/active_trophy.svg
@@ -1,3 +1,3 @@
-<svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
-<path d="M7 4V2h10v2h4v4c0 3.31-2.69 6-6 6v2h3v2H6v-2h3v-2c-3.31 0-6-2.69-6-6V4h4z" fill="currentColor"/>
+<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24">
+  <path d="M19 5h-2V3H7v2H5C3.9 5 3 5.9 3 7v1c0 2.55 1.92 4.63 4.39 4.94.63 1.5 1.98 2.63 3.61 2.96V19H7v2h10v-2h-4v-3.1c1.63-.33 2.98-1.46 3.61-2.96C19.08 12.63 21 10.55 21 8V7c0-1.1-.9-2-2-2zM5 8V7h2v3.82C5.84 10.4 5 9.3 5 8zm7 6c-1.65 0-3-1.35-3-3V5h6v6c0 1.65-1.35 3-3 3zm7-6c0 1.3-.84 2.4-2 2.82V7h2v1z" fill="#275072"/>
 </svg>

--- a/assets/icons/trophy.svg
+++ b/assets/icons/trophy.svg
@@ -1,3 +1,3 @@
-<svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
-<path d="M7 4V2h10v2h4v4c0 3.31-2.69 6-6 6v2h3v2H6v-2h3v-2c-3.31 0-6-2.69-6-6V4h4z" fill="currentColor"/>
+<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24">
+  <path d="M19 5h-2V3H7v2H5C3.9 5 3 5.9 3 7v1c0 2.55 1.92 4.63 4.39 4.94.63 1.5 1.98 2.63 3.61 2.96V19H7v2h10v-2h-4v-3.1c1.63-.33 2.98-1.46 3.61-2.96C19.08 12.63 21 10.55 21 8V7c0-1.1-.9-2-2-2zM5 8V7h2v3.82C5.84 10.4 5 9.3 5 8zm7 6c-1.65 0-3-1.35-3-3V5h6v6c0 1.65-1.35 3-3 3zm7-6c0 1.3-.84 2.4-2 2.82V7h2v1z" fill="#c5c5c5"/>
 </svg>


### PR DESCRIPTION
## Summary
- use outlined trophy icon for the Challenges tab
- match the primary and inactive colors with other navbar icons

## Testing
- `n/a` (assets update only)

------
https://chatgpt.com/codex/tasks/task_b_687d1f5ec2e0832caf691125327dbbdf