### PR TITLE
Add join challenge card

### DIFF
--- a/lib/features/challenges/presentation/screens/challenges_screen.dart
+++ b/lib/features/challenges/presentation/screens/challenges_screen.dart
@@ -136,6 +136,114 @@ class ChallengesScreen extends StatelessWidget {
     );
   }
 
+  /// Builds the card allowing a user to join an upcoming challenge.
+  Widget _joinChallengeCard() {
+    const borderColor = Color(0xFFFEEBCB);
+    const badgeColor = Color(0xFFFFF3E0);
+    const highlightColor = Color(0xFFF9A825);
+
+    return Directionality(
+      textDirection: TextDirection.rtl,
+      child: Padding(
+        padding: const EdgeInsets.only(top: 24),
+        child: Container(
+          decoration: BoxDecoration(
+            color: Colors.white,
+            border: Border.all(color: borderColor),
+            borderRadius: BorderRadius.circular(12),
+          ),
+          child: Column(
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              Padding(
+                padding: const EdgeInsets.all(8.0),
+                child: Container(
+                  padding: const EdgeInsets.symmetric(
+                    horizontal: 8,
+                    vertical: 4,
+                  ),
+                  decoration: BoxDecoration(
+                    color: badgeColor,
+                    borderRadius: BorderRadius.circular(20),
+                  ),
+                  child: Row(
+                    mainAxisSize: MainAxisSize.min,
+                    children: const [
+                      Icon(Icons.access_time, color: highlightColor, size: 16),
+                      SizedBox(width: 4),
+                      Text(
+                        'انضم للتحدي - اليوم 7:30 م',
+                        style: TextStyle(
+                          color: highlightColor,
+                          fontWeight: FontWeight.bold,
+                          fontSize: 12,
+                        ),
+                      ),
+                    ],
+                  ),
+                ),
+              ),
+              Row(
+                mainAxisAlignment: MainAxisAlignment.spaceEvenly,
+                children: [
+                  Column(
+                    children: const [
+                      Text(
+                        'الابطال',
+                        style: TextStyle(fontWeight: FontWeight.bold),
+                      ),
+                      SizedBox(height: 4),
+                      CircleAvatar(
+                        radius: 20,
+                        backgroundImage:
+                            AssetImage('assets/images/profile_image.png'),
+                      ),
+                    ],
+                  ),
+                  Column(
+                    children: [
+                      const Text(
+                        'VS',
+                        style: TextStyle(
+                          fontWeight: FontWeight.bold,
+                          color: highlightColor,
+                        ),
+                      ),
+                      Container(
+                        margin: const EdgeInsets.only(top: 4),
+                        height: 2,
+                        width: 20,
+                        color: highlightColor,
+                      ),
+                    ],
+                  ),
+                  Column(
+                    children: [
+                      const Text(
+                        'انضم',
+                        style: TextStyle(fontWeight: FontWeight.bold),
+                      ),
+                      const SizedBox(height: 4),
+                      Container(
+                        width: 40,
+                        height: 40,
+                        decoration: const BoxDecoration(
+                          color: badgeColor,
+                          shape: BoxShape.circle,
+                        ),
+                        child: const Icon(Icons.add, color: highlightColor),
+                      ),
+                    ],
+                  ),
+                ],
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+
   @override
   Widget build(BuildContext context) {
     const darkBlue = Color(0xFF23425F);
@@ -193,6 +301,7 @@ class ChallengesScreen extends StatelessWidget {
                   color: Colors.grey,
                 ),
               ),
+              _joinChallengeCard(),
               _completedChallengeCard(),
             ],
           ),

--- a/test/challenges_screen_test.dart
+++ b/test/challenges_screen_test.dart
@@ -32,4 +32,17 @@ void main() {
     expect(find.text('تحدي مكتمل - اليوم 8:00 م'), findsOneWidget);
     expect(find.text('عرض التفاصيل'), findsOneWidget);
   });
+
+  testWidgets('challenge screen contains join challenge card', (tester) async {
+    tester.binding.window.physicalSizeTestValue = const Size(1200, 800);
+    tester.binding.window.devicePixelRatioTestValue = 1.0;
+    addTearDown(() {
+      tester.binding.window.clearPhysicalSizeTestValue();
+      tester.binding.window.clearDevicePixelRatioTestValue();
+    });
+    await tester.pumpWidget(const MaterialApp(home: ChallengesScreen()));
+    await tester.pumpAndSettle();
+    expect(find.text('انضم للتحدي - اليوم 7:30 م'), findsOneWidget);
+    expect(find.byIcon(Icons.add), findsOneWidget);
+  });
 }


### PR DESCRIPTION
## Summary
- add widget to show join challenge card on Challenges page
- test join challenge card in challenge screen tests

## Testing
- `flutter analyze`
- `flutter test`

------
https://chatgpt.com/codex/tasks/task_b_687d2bf65d18832caece972c6fad9555