### PR TITLE
Implement RTL challenge tabs

### DIFF
--- a/assets/translations/ar-EG.json
+++ b/assets/translations/ar-EG.json
@@ -172,5 +172,8 @@
 "location_req3":"فى حالة الالغاء لن تستطيع العثور علي المباريات القريبه منك ",
 "challenge_more":"المزيد",
 "challenge_updates":"التحديثات",
-"challenge_create_team":"إنشاء فريق"
+"challenge_create_team":"إنشاء فريق",
+"league_schedule":"جدول الدوري",
+"championships":"البطولات",
+"under_construction":"\ud83d\udea7 تحت الإنشاء"
 }

--- a/assets/translations/en-US.json
+++ b/assets/translations/en-US.json
@@ -162,5 +162,8 @@
 "location_req3": "If canceled, you will not be able to find nearby matches.",
 "challenge_more": "More",
 "challenge_updates": "Updates",
-"challenge_create_team": "Create Team"
+  "challenge_create_team": "Create Team",
+  "league_schedule": "League Schedule",
+  "championships": "Championships",
+  "under_construction": "\ud83d\udea7 Under Construction"
 }

--- a/lib/core/app_strings/locale_keys.dart
+++ b/lib/core/app_strings/locale_keys.dart
@@ -216,4 +216,7 @@ abstract class LocaleKeys {
   static const challenge_more = 'challenge_more';
   static const challenge_updates = 'challenge_updates';
   static const challenge_create_team = 'challenge_create_team';
+  static const league_schedule = 'league_schedule';
+  static const championships = 'championships';
+  static const under_construction = 'under_construction';
 }

--- a/lib/features/challenges/presentation/screens/challenges_screen.dart
+++ b/lib/features/challenges/presentation/screens/challenges_screen.dart
@@ -4,8 +4,28 @@ import 'package:remontada/core/app_strings/locale_keys.dart';
 import 'package:remontada/shared/widgets/customtext.dart';
 
 /// Placeholder screen shown for the upcoming Challenges feature.
-class ChallengesScreen extends StatelessWidget {
+class ChallengesScreen extends StatefulWidget {
   const ChallengesScreen({super.key});
+
+  @override
+  State<ChallengesScreen> createState() => _ChallengesScreenState();
+}
+
+class _ChallengesScreenState extends State<ChallengesScreen>
+    with SingleTickerProviderStateMixin {
+  late final TabController _tabController;
+
+  @override
+  void initState() {
+    super.initState();
+    _tabController = TabController(length: 3, vsync: this);
+  }
+
+  @override
+  void dispose() {
+    _tabController.dispose();
+    super.dispose();
+  }
 
   /// Builds the card displaying a completed challenge summary.
   Widget _completedChallengeCard() {
@@ -195,8 +215,9 @@ class ChallengesScreen extends StatelessWidget {
                       SizedBox(height: 4),
                       CircleAvatar(
                         radius: 20,
-                        backgroundImage:
-                            AssetImage('assets/images/profile_image.png'),
+                        backgroundImage: AssetImage(
+                          'assets/images/profile_image.png',
+                        ),
                       ),
                     ],
                   ),
@@ -237,7 +258,7 @@ class ChallengesScreen extends StatelessWidget {
                   ),
                 ],
               ),
-              SizedBox(height: 15,)
+              SizedBox(height: 15),
             ],
           ),
         ),
@@ -293,10 +314,61 @@ class ChallengesScreen extends StatelessWidget {
                   ],
                 ),
               ),
-              _completedChallengeCard(),
-              _joinChallengeCard(),
-              const Spacer(),
-
+              const SizedBox(height: 16),
+              Directionality(
+                textDirection: TextDirection.rtl,
+                child: Container(
+                  padding: const EdgeInsets.all(4),
+                  decoration: BoxDecoration(
+                    color: Color(0xFFF2F2F2),
+                    borderRadius: BorderRadius.circular(25),
+                  ),
+                  child: TabBar(
+                    controller: _tabController,
+                    indicator: BoxDecoration(
+                      color: darkBlue,
+                      borderRadius: BorderRadius.circular(20),
+                    ),
+                    labelColor: Colors.white,
+                    unselectedLabelColor: Colors.grey,
+                    tabs: const [
+                      Tab(text: 'التحديات'),
+                      Tab(text: 'جدول الدوري'),
+                      Tab(text: 'البطولات'),
+                    ],
+                  ),
+                ),
+              ),
+              const SizedBox(height: 16),
+              Expanded(
+                child: TabBarView(
+                  controller: _tabController,
+                  children: [
+                    SingleChildScrollView(
+                      child: Column(
+                        children: [
+                          _completedChallengeCard(),
+                          _joinChallengeCard(),
+                        ],
+                      ),
+                    ),
+                    const Center(
+                      child: Text(
+                        '🚧 تحت الإنشاء',
+                        style: TextStyle(color: Colors.grey),
+                        textAlign: TextAlign.center,
+                      ),
+                    ),
+                    const Center(
+                      child: Text(
+                        '🚧 تحت الإنشاء',
+                        style: TextStyle(color: Colors.grey),
+                        textAlign: TextAlign.center,
+                      ),
+                    ),
+                  ],
+                ),
+              ),
             ],
           ),
         ),

--- a/lib/features/challenges/presentation/screens/challenges_screen.dart
+++ b/lib/features/challenges/presentation/screens/challenges_screen.dart
@@ -331,10 +331,10 @@ class _ChallengesScreenState extends State<ChallengesScreen>
                     ),
                     labelColor: Colors.white,
                     unselectedLabelColor: Colors.grey,
-                    tabs: const [
-                      Tab(text: 'التحديات'),
-                      Tab(text: 'جدول الدوري'),
-                      Tab(text: 'البطولات'),
+                    tabs: [
+                      Tab(text: LocaleKeys.challenges_nav.tr()),
+                      Tab(text: LocaleKeys.league_schedule.tr()),
+                      Tab(text: LocaleKeys.championships.tr()),
                     ],
                   ),
                 ),
@@ -352,17 +352,17 @@ class _ChallengesScreenState extends State<ChallengesScreen>
                         ],
                       ),
                     ),
-                    const Center(
+                    Center(
                       child: Text(
-                        '🚧 تحت الإنشاء',
-                        style: TextStyle(color: Colors.grey),
+                        LocaleKeys.under_construction.tr(),
+                        style: const TextStyle(color: Colors.grey),
                         textAlign: TextAlign.center,
                       ),
                     ),
-                    const Center(
+                    Center(
                       child: Text(
-                        '🚧 تحت الإنشاء',
-                        style: TextStyle(color: Colors.grey),
+                        LocaleKeys.under_construction.tr(),
+                        style: const TextStyle(color: Colors.grey),
                         textAlign: TextAlign.center,
                       ),
                     ),

--- a/test/challenges_screen_test.dart
+++ b/test/challenges_screen_test.dart
@@ -18,9 +18,7 @@ void main() {
     expect(find.byIcon(Icons.more_horiz), findsOneWidget);
   });
 
-  testWidgets('challenge screen contains completed challenge card', (
-    tester,
-  ) async {
+  testWidgets('first tab shows challenge cards', (tester) async {
     tester.binding.window.physicalSizeTestValue = const Size(1200, 800);
     tester.binding.window.devicePixelRatioTestValue = 1.0;
     addTearDown(() {
@@ -30,10 +28,10 @@ void main() {
     await tester.pumpWidget(const MaterialApp(home: ChallengesScreen()));
     await tester.pumpAndSettle();
     expect(find.text('تحدي مكتمل - اليوم 8:00 م'), findsOneWidget);
-    expect(find.text('عرض التفاصيل'), findsOneWidget);
+    expect(find.text('انضم للتحدي - اليوم 7:30 م'), findsOneWidget);
   });
 
-  testWidgets('challenge screen contains join challenge card', (tester) async {
+  testWidgets('other tabs show under construction placeholder', (tester) async {
     tester.binding.window.physicalSizeTestValue = const Size(1200, 800);
     tester.binding.window.devicePixelRatioTestValue = 1.0;
     addTearDown(() {
@@ -42,7 +40,11 @@ void main() {
     });
     await tester.pumpWidget(const MaterialApp(home: ChallengesScreen()));
     await tester.pumpAndSettle();
-    expect(find.text('انضم للتحدي - اليوم 7:30 م'), findsOneWidget);
-    expect(find.byIcon(Icons.add), findsOneWidget);
+    await tester.tap(find.text('جدول الدوري'));
+    await tester.pumpAndSettle();
+    expect(find.text('🚧 تحت الإنشاء'), findsOneWidget);
+    await tester.tap(find.text('البطولات'));
+    await tester.pumpAndSettle();
+    expect(find.text('🚧 تحت الإنشاء'), findsOneWidget);
   });
 }

--- a/test/challenges_screen_test.dart
+++ b/test/challenges_screen_test.dart
@@ -40,11 +40,11 @@ void main() {
     });
     await tester.pumpWidget(const MaterialApp(home: ChallengesScreen()));
     await tester.pumpAndSettle();
-    await tester.tap(find.text('جدول الدوري'));
+    await tester.tap(find.byType(Tab).at(1));
     await tester.pumpAndSettle();
-    expect(find.text('🚧 تحت الإنشاء'), findsOneWidget);
-    await tester.tap(find.text('البطولات'));
+    expect(find.text('under_construction'), findsOneWidget);
+    await tester.tap(find.byType(Tab).at(2));
     await tester.pumpAndSettle();
-    expect(find.text('🚧 تحت الإنشاء'), findsOneWidget);
+    expect(find.text('under_construction'), findsOneWidget);
   });
 }


### PR DESCRIPTION
## Summary
- add stateful tabbed layout to `ChallengesScreen`
- show challenge cards in first tab and placeholders in others
- test tab navigation and placeholder text

## Testing
- `flutter analyze`
- `flutter test`
- `pytest`
- `ruff check .`
- `flake8 --exclude=ios/Flutter/ephemeral .`

------
https://chatgpt.com/codex/tasks/task_b_687d48bfae68832c91b9b50d0e39057a