### PR TITLE
Add new challenge creation button

### DIFF
--- a/assets/translations/ar-EG.json
+++ b/assets/translations/ar-EG.json
@@ -173,6 +173,7 @@
 "challenge_more":"المزيد",
 "challenge_updates":"التحديات",
 "challenge_create_team":"إنشاء فريق",
+"challenge_create_challenge":"إنشاء تحدي جديد",
 "league_schedule":"جدول الدوري",
 "championships":"البطولات",
 "under_construction":"\ud83d\udea7 تحت الإنشاء"

--- a/assets/translations/en-US.json
+++ b/assets/translations/en-US.json
@@ -163,6 +163,7 @@
 "challenge_more": "More",
 "challenge_updates": "Challanges",
   "challenge_create_team": "Create Team",
+  "challenge_create_challenge": "Create New Challenge",
   "league_schedule": "League Schedule",
   "championships": "Championships",
   "under_construction": "\ud83d\udea7 Under Construction"

--- a/lib/core/app_strings/locale_keys.dart
+++ b/lib/core/app_strings/locale_keys.dart
@@ -216,6 +216,7 @@ abstract class LocaleKeys {
   static const challenge_more = 'challenge_more';
   static const challenge_updates = 'challenge_updates';
   static const challenge_create_team = 'challenge_create_team';
+  static const challenge_create_challenge = 'challenge_create_challenge';
   static const league_schedule = 'league_schedule';
   static const championships = 'championships';
   static const under_construction = 'under_construction';

--- a/lib/features/challenges/presentation/screens/challenges_screen.dart
+++ b/lib/features/challenges/presentation/screens/challenges_screen.dart
@@ -279,6 +279,43 @@ class _ChallengesScreenState extends State<ChallengesScreen>
     );
   }
 
+  /// Builds a button allowing a user to initiate a new challenge.
+  Widget _createChallengeButton() {
+    const darkBlue = Color(0xFF23425F);
+    return Padding(
+      padding: const EdgeInsets.symmetric(horizontal: 8),
+      child: InkWell(
+        borderRadius: BorderRadius.circular(12),
+        onTap: () {},
+        child: Container(
+          width: double.infinity,
+          padding: const EdgeInsets.symmetric(vertical: 16),
+          decoration: BoxDecoration(
+            gradient: const LinearGradient(
+              colors: [Colors.white, Color(0xFFF5F5F5)],
+            ),
+            border: Border.all(color: darkBlue),
+            borderRadius: BorderRadius.circular(12),
+          ),
+          child: Column(
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              const Icon(Icons.add, color: darkBlue),
+              const SizedBox(height: 4),
+              Text(
+                LocaleKeys.challenge_create_challenge.tr(),
+                style: const TextStyle(
+                  color: darkBlue,
+                  fontWeight: FontWeight.bold,
+                ),
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+
   /// Returns the carousel slider displayed at the top of the page.
   Widget _buildCarousel() {
     return Stack(
@@ -403,6 +440,9 @@ class _ChallengesScreenState extends State<ChallengesScreen>
                     SingleChildScrollView(
                       child: Column(
                         children: [
+                          const SizedBox(height: 12),
+                          _createChallengeButton(),
+                          const SizedBox(height: 12),
                           _completedChallengeCard(),
                           _joinChallengeCard(),
                         ],

--- a/test/challenges_screen_test.dart
+++ b/test/challenges_screen_test.dart
@@ -40,6 +40,7 @@ void main() {
     });
     await tester.pumpWidget(const MaterialApp(home: ChallengesScreen()));
     await tester.pumpAndSettle();
+    expect(find.text('challenge_create_challenge'), findsOneWidget);
     expect(find.text('تحدي مكتمل - اليوم 8:00 م'), findsOneWidget);
     expect(find.text('انضم للتحدي - اليوم 7:30 م'), findsOneWidget);
   });


### PR DESCRIPTION
## Summary
- add localization key for creating a new challenge
- translate new key for English and Arabic
- add create challenge button on Challenges screen
- test for new button

## Testing
- `pytest -q`
- `ruff check .`
- `flutter test`


------
https://chatgpt.com/codex/tasks/task_b_687d5899f98c832c88f7dac2ccb60c22