### PR TITLE
Add league table widgets to Challenges

### DIFF
--- a/assets/translations/ar-EG.json
+++ b/assets/translations/ar-EG.json
@@ -185,4 +185,15 @@
 "how_challenges_step3_title":"متابعة التحديات",
 "how_challenges_step3_subtitle":"انقر على أي تحدي مكتمل لعرض التفاصيل ومتابعة النتائج",
 "how_challenges_tip":"نصيحة: تأكد من إنشاء فريقك أولاً قبل المشاركة في التحديات"
+"league_table_title":"جدول ترتيب الدوري",
+"league_rank":"#",
+"league_team":"الفريق",
+"league_played":"لعب",
+"league_won":"فاز",
+"league_drawn":"تعادل",
+"league_lost":"خسر",
+"league_goals_for":"له",
+"league_goals_against":"عليه",
+"league_goal_diff":"الفرق",
+"league_points":"النقاط"
 }

--- a/assets/translations/en-US.json
+++ b/assets/translations/en-US.json
@@ -175,4 +175,15 @@
   "how_challenges_step3_title": "Track challenges",
   "how_challenges_step3_subtitle": "Tap any completed challenge to view details and follow the results",
   "how_challenges_tip": "Tip: Make sure to create your team first before participating in challenges"
+  "league_table_title": "League Standings",
+  "league_rank": "#",
+  "league_team": "Team",
+  "league_played": "Played",
+  "league_won": "Won",
+  "league_drawn": "Drawn",
+  "league_lost": "Lost",
+  "league_goals_for": "GF",
+  "league_goals_against": "GA",
+  "league_goal_diff": "GD",
+  "league_points": "Pts"
 }

--- a/lib/core/app_strings/locale_keys.dart
+++ b/lib/core/app_strings/locale_keys.dart
@@ -228,4 +228,15 @@ abstract class LocaleKeys {
   static const how_challenges_step3_title = 'how_challenges_step3_title';
   static const how_challenges_step3_subtitle = 'how_challenges_step3_subtitle';
   static const how_challenges_tip = 'how_challenges_tip';
+  static const league_table_title = 'league_table_title';
+  static const league_rank = 'league_rank';
+  static const league_team = 'league_team';
+  static const league_played = 'league_played';
+  static const league_won = 'league_won';
+  static const league_drawn = 'league_drawn';
+  static const league_lost = 'league_lost';
+  static const league_goals_for = 'league_goals_for';
+  static const league_goals_against = 'league_goals_against';
+  static const league_goal_diff = 'league_goal_diff';
+  static const league_points = 'league_points';
 }

--- a/lib/features/challenges/presentation/screens/challenges_screen.dart
+++ b/lib/features/challenges/presentation/screens/challenges_screen.dart
@@ -24,6 +24,61 @@ class _ChallengesScreenState extends State<ChallengesScreen>
     'assets/images/slider.png',
     'assets/images/slider.png',
   ];
+  /// Dummy league standings used in the league table widget.
+  final List<Map<String, dynamic>> _standings = [
+    {
+      'rank': 1,
+      'name': 'الفهود',
+      'logo': 'assets/images/profile_image.png',
+      'played': 5,
+      'won': 4,
+      'drawn': 1,
+      'lost': 0,
+      'gf': 12,
+      'ga': 3,
+      'gd': 9,
+      'pts': 13,
+    },
+    {
+      'rank': 2,
+      'name': 'النسور',
+      'logo': 'assets/images/profile_image.png',
+      'played': 5,
+      'won': 3,
+      'drawn': 1,
+      'lost': 1,
+      'gf': 9,
+      'ga': 6,
+      'gd': 3,
+      'pts': 10,
+    },
+    {
+      'rank': 3,
+      'name': 'الصقور',
+      'logo': 'assets/images/profile_image.png',
+      'played': 5,
+      'won': 2,
+      'drawn': 2,
+      'lost': 1,
+      'gf': 7,
+      'ga': 5,
+      'gd': 2,
+      'pts': 8,
+    },
+    {
+      'rank': 4,
+      'name': 'الابطال',
+      'logo': 'assets/images/profile_image.png',
+      'played': 5,
+      'won': 1,
+      'drawn': 1,
+      'lost': 3,
+      'gf': 5,
+      'ga': 10,
+      'gd': -5,
+      'pts': 4,
+    },
+  ];
   int _currentSlideIndex = 0;
 
   @override
@@ -423,6 +478,105 @@ class _ChallengesScreenState extends State<ChallengesScreen>
     );
   }
 
+  /// Displays the league table header with a trophy icon.
+  Widget _leagueHeaderCard() {
+    const darkBlue = Color(0xFF23425F);
+    return Directionality(
+      textDirection: TextDirection.rtl,
+      child: Container(
+        decoration: const BoxDecoration(
+          color: darkBlue,
+          borderRadius: BorderRadius.only(
+            topLeft: Radius.circular(12),
+            topRight: Radius.circular(12),
+          ),
+        ),
+        padding: const EdgeInsets.all(12),
+        child: Row(
+          children: [
+            const Icon(Icons.emoji_events, color: Colors.white),
+            const SizedBox(width: 8),
+            Text(
+              LocaleKeys.league_table_title.tr(),
+              style: const TextStyle(
+                color: Colors.white,
+                fontWeight: FontWeight.bold,
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  /// Builds the table displaying current league standings.
+  Widget _leagueTable() {
+    return Directionality(
+      textDirection: TextDirection.rtl,
+      child: Container(
+        decoration: BoxDecoration(
+          color: Colors.white,
+          borderRadius: const BorderRadius.only(
+            bottomLeft: Radius.circular(12),
+            bottomRight: Radius.circular(12),
+          ),
+          border: Border.all(color: Colors.grey.shade300),
+        ),
+        child: SingleChildScrollView(
+          scrollDirection: Axis.horizontal,
+          child: DataTable(
+            columns: [
+              DataColumn(label: Text(LocaleKeys.league_rank.tr())),
+              DataColumn(label: Text(LocaleKeys.league_team.tr())),
+              DataColumn(label: Text(LocaleKeys.league_played.tr())),
+              DataColumn(label: Text(LocaleKeys.league_won.tr())),
+              DataColumn(label: Text(LocaleKeys.league_drawn.tr())),
+              DataColumn(label: Text(LocaleKeys.league_lost.tr())),
+              DataColumn(label: Text(LocaleKeys.league_goals_for.tr())),
+              DataColumn(label: Text(LocaleKeys.league_goals_against.tr())),
+              DataColumn(label: Text(LocaleKeys.league_goal_diff.tr())),
+              DataColumn(label: Text(LocaleKeys.league_points.tr())),
+            ],
+            rows: _standings.map((team) {
+              final int gd = team['gd'] as int;
+              return DataRow(
+                cells: [
+                  DataCell(Text(team['rank'].toString())),
+                  DataCell(Row(
+                    children: [
+                      CircleAvatar(
+                        radius: 12,
+                        backgroundImage: AssetImage(team['logo'] as String),
+                      ),
+                      const SizedBox(width: 4),
+                      Text(
+                        team['name'] as String,
+                        style: const TextStyle(fontWeight: FontWeight.bold),
+                      ),
+                    ],
+                  )),
+                  DataCell(Text(team['played'].toString())),
+                  DataCell(Text(team['won'].toString())),
+                  DataCell(Text(team['drawn'].toString())),
+                  DataCell(Text(team['lost'].toString())),
+                  DataCell(Text(team['gf'].toString())),
+                  DataCell(Text(team['ga'].toString())),
+                  DataCell(Text(
+                    gd.toString(),
+                    style: TextStyle(
+                      color: gd >= 0 ? Colors.green : Colors.red,
+                    ),
+                  )),
+                  DataCell(Text(team['pts'].toString())),
+                ],
+              );
+            }).toList(),
+          ),
+        ),
+      ),
+    );
+  }
+
   /// Returns the carousel slider displayed at the top of the page.
   Widget _buildCarousel() {
     return Stack(
@@ -558,11 +712,13 @@ class _ChallengesScreenState extends State<ChallengesScreen>
                         ],
                       ),
                     ),
-                    Center(
-                      child: Text(
-                        LocaleKeys.under_construction.tr(),
-                        style: const TextStyle(color: Colors.grey),
-                        textAlign: TextAlign.center,
+                    SingleChildScrollView(
+                      child: Column(
+                        children: [
+                          _leagueHeaderCard(),
+                          const SizedBox(height: 8),
+                          _leagueTable(),
+                        ],
                       ),
                     ),
                     Center(

--- a/test/challenges_screen_test.dart
+++ b/test/challenges_screen_test.dart
@@ -55,11 +55,23 @@ void main() {
     });
     await tester.pumpWidget(const MaterialApp(home: ChallengesScreen()));
     await tester.pumpAndSettle();
-    await tester.tap(find.byType(Tab).at(1));
-    await tester.pumpAndSettle();
-    expect(find.text('under_construction'), findsOneWidget);
     await tester.tap(find.byType(Tab).at(2));
     await tester.pumpAndSettle();
     expect(find.text('under_construction'), findsOneWidget);
+  });
+
+  testWidgets('league tab shows standings table', (tester) async {
+    tester.binding.window.physicalSizeTestValue = const Size(1200, 800);
+    tester.binding.window.devicePixelRatioTestValue = 1.0;
+    addTearDown(() {
+      tester.binding.window.clearPhysicalSizeTestValue();
+      tester.binding.window.clearDevicePixelRatioTestValue();
+    });
+    await tester.pumpWidget(const MaterialApp(home: ChallengesScreen()));
+    await tester.pumpAndSettle();
+    await tester.tap(find.byType(Tab).at(1));
+    await tester.pumpAndSettle();
+    expect(find.text('league_table_title'), findsOneWidget);
+    expect(find.byType(DataTable), findsOneWidget);
   });
 }


### PR DESCRIPTION
## Summary
- add league table translations
- expose new locale keys
- implement league standings header and table
- show new widgets on league schedule tab
- test updated tab content

## Testing
- `ruff check .`
- `flutter test`

------
https://chatgpt.com/codex/tasks/task_b_687d61f23b20832c9a826e686339a8ad