### PR TITLE
Add championship cards to challenges screen

### DIFF
--- a/assets/translations/ar-EG.json
+++ b/assets/translations/ar-EG.json
@@ -195,5 +195,10 @@
 "league_goals_for":"له",
 "league_goals_against":"عليه",
 "league_goal_diff":"الفرق",
-"league_points":"النقاط"
+"league_points":"النقاط",
+"super_remontada_championship":"بطولة سوبر ريمونتادا",
+"elite_remontada_championship":"بطولة نخبة ريمونتادا",
+"champions_league_remontada_championship":"بطولة دوري أبطال ريمونتادا",
+"rounds_count":"عدد الجولات: {}",
+"available_to_join":"متاح للانضمام"
 }

--- a/assets/translations/en-US.json
+++ b/assets/translations/en-US.json
@@ -174,7 +174,7 @@
   "how_challenges_step2_subtitle": "Tap the '+' icon to join an existing challenge against another team",
   "how_challenges_step3_title": "Track challenges",
   "how_challenges_step3_subtitle": "Tap any completed challenge to view details and follow the results",
-  "how_challenges_tip": "Tip: Make sure to create your team first before participating in challenges"
+  "how_challenges_tip": "Tip: Make sure to create your team first before participating in challenges",
   "league_table_title": "League Standings",
   "league_rank": "#",
   "league_team": "Team",
@@ -185,5 +185,10 @@
   "league_goals_for": "GF",
   "league_goals_against": "GA",
   "league_goal_diff": "GD",
-  "league_points": "Pts"
+  "league_points": "Pts",
+  "super_remontada_championship": "Super Remontada Championship",
+  "elite_remontada_championship": "Elite Remontada Championship",
+  "champions_league_remontada_championship": "Remontada Champions League",
+  "rounds_count": "Rounds: {}",
+  "available_to_join": "Available to Join"
 }

--- a/lib/core/app_strings/locale_keys.dart
+++ b/lib/core/app_strings/locale_keys.dart
@@ -219,6 +219,14 @@ abstract class LocaleKeys {
   static const challenge_create_challenge = 'challenge_create_challenge';
   static const league_schedule = 'league_schedule';
   static const championships = 'championships';
+  static const super_remontada_championship =
+      'super_remontada_championship';
+  static const elite_remontada_championship =
+      'elite_remontada_championship';
+  static const champions_league_remontada_championship =
+      'champions_league_remontada_championship';
+  static const rounds_count = 'rounds_count';
+  static const available_to_join = 'available_to_join';
   static const under_construction = 'under_construction';
   static const how_challenges_work_title = 'how_challenges_work_title';
   static const how_challenges_step1_title = 'how_challenges_step1_title';

--- a/lib/features/challenges/presentation/screens/challenges_screen.dart
+++ b/lib/features/challenges/presentation/screens/challenges_screen.dart
@@ -6,6 +6,7 @@ import 'package:remontada/core/extensions/all_extensions.dart';
 import 'package:remontada/core/utils/extentions.dart';
 import 'package:remontada/features/home/presentation/widgets/custom_dots.dart';
 import 'package:remontada/shared/widgets/customtext.dart';
+import '../widgets/championship_card.dart';
 
 /// Placeholder screen shown for the upcoming Challenges feature.
 class ChallengesScreen extends StatefulWidget {
@@ -777,11 +778,15 @@ class _ChallengesScreenState extends State<ChallengesScreen>
                         ],
                       ),
                     ),
-                    Center(
-                      child: Text(
-                        LocaleKeys.under_construction.tr(),
-                        style: const TextStyle(color: Colors.grey),
-                        textAlign: TextAlign.center,
+                    SingleChildScrollView(
+                      child: Column(
+                        children: const [
+                          SuperRemontadaChampionshipCard(),
+                          SizedBox(height: 12),
+                          EliteRemontadaChampionshipCard(),
+                          SizedBox(height: 12),
+                          RemontadaChampionsLeagueCard(),
+                        ],
                       ),
                     ),
                   ],

--- a/lib/features/challenges/presentation/widgets/championship_card.dart
+++ b/lib/features/challenges/presentation/widgets/championship_card.dart
@@ -1,0 +1,143 @@
+import 'package:flutter/material.dart';
+import 'package:easy_localization/easy_localization.dart' hide TextDirection;
+import 'package:remontada/core/app_strings/locale_keys.dart';
+
+/// Base widget that renders a championship card with a title, rounds
+/// information and a join badge.
+class ChampionshipCard extends StatelessWidget {
+  const ChampionshipCard({
+    super.key,
+    required this.titleKey,
+    required this.rounds,
+    required this.icon,
+    required this.gradientColors,
+  });
+
+  /// Localization key for the card title.
+  final String titleKey;
+
+  /// Number of rounds played in the championship.
+  final int rounds;
+
+  /// Icon displayed on the top right of the card.
+  final IconData icon;
+
+  /// Gradient colors used as the card background.
+  final List<Color> gradientColors;
+
+  @override
+  Widget build(BuildContext context) {
+    return Directionality(
+      textDirection: TextDirection.rtl,
+      child: Card(
+        shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(12)),
+        margin: const EdgeInsets.symmetric(horizontal: 12, vertical: 8),
+        child: Container(
+          padding: const EdgeInsets.all(12),
+          decoration: BoxDecoration(
+            gradient: LinearGradient(colors: gradientColors),
+            borderRadius: BorderRadius.circular(12),
+          ),
+          child: Row(
+            children: [
+              Expanded(
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    Row(
+                      children: [
+                        Expanded(
+                          child: Text(
+                            titleKey.tr(),
+                            style: const TextStyle(
+                              fontWeight: FontWeight.bold,
+                              fontSize: 16,
+                            ),
+                          ),
+                        ),
+                        Icon(icon, color: Colors.white),
+                      ],
+                    ),
+                    const SizedBox(height: 8),
+                    Row(
+                      children: [
+                        const Icon(Icons.emoji_events, size: 20, color: Colors.white),
+                        const SizedBox(width: 4),
+                        Text(
+                          LocaleKeys.rounds_count.tr(args: [rounds.toString()]),
+                          style: const TextStyle(color: Colors.white),
+                        ),
+                      ],
+                    ),
+                    const SizedBox(height: 8),
+                    Container(
+                      padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 4),
+                      decoration: BoxDecoration(
+                        color: Colors.white,
+                        borderRadius: BorderRadius.circular(20),
+                      ),
+                      child: Text(
+                        LocaleKeys.available_to_join.tr(),
+                        style: const TextStyle(
+                          color: Colors.green,
+                          fontWeight: FontWeight.bold,
+                        ),
+                      ),
+                    ),
+                  ],
+                ),
+              ),
+              const SizedBox(width: 8),
+              const Icon(Icons.arrow_back_ios, color: Colors.white),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+/// Championship card for the "سوبر ريمونتادا" competition.
+class SuperRemontadaChampionshipCard extends StatelessWidget {
+  const SuperRemontadaChampionshipCard({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return ChampionshipCard(
+      titleKey: LocaleKeys.super_remontada_championship,
+      rounds: 4,
+      icon: Icons.star,
+      gradientColors: [Colors.blueGrey.shade200, Colors.blue.shade200],
+    );
+  }
+}
+
+/// Championship card for the "نخبة ريمونتادا" competition.
+class EliteRemontadaChampionshipCard extends StatelessWidget {
+  const EliteRemontadaChampionshipCard({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return ChampionshipCard(
+      titleKey: LocaleKeys.elite_remontada_championship,
+      rounds: 8,
+      icon: Icons.diamond_outlined,
+      gradientColors: [Colors.purple.shade200, Colors.deepPurple.shade200],
+    );
+  }
+}
+
+/// Championship card for the "دوري أبطال ريمونتادا" competition.
+class RemontadaChampionsLeagueCard extends StatelessWidget {
+  const RemontadaChampionsLeagueCard({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return ChampionshipCard(
+      titleKey: LocaleKeys.champions_league_remontada_championship,
+      rounds: 16,
+      icon: Icons.emoji_events,
+      gradientColors: [Colors.lightBlue.shade200, Colors.lightBlueAccent.shade100],
+    );
+  }
+}

--- a/test/challenges_screen_test.dart
+++ b/test/challenges_screen_test.dart
@@ -46,7 +46,7 @@ void main() {
     expect(find.text('تحدي مكتمل - اليوم 8:00 م'), findsOneWidget);
   });
 
-  testWidgets('other tabs show under construction placeholder', (tester) async {
+  testWidgets('championship tab shows championship cards', (tester) async {
     tester.binding.window.physicalSizeTestValue = const Size(1200, 800);
     tester.binding.window.devicePixelRatioTestValue = 1.0;
     addTearDown(() {
@@ -57,7 +57,9 @@ void main() {
     await tester.pumpAndSettle();
     await tester.tap(find.byType(Tab).at(2));
     await tester.pumpAndSettle();
-    expect(find.text('under_construction'), findsOneWidget);
+    expect(find.text('super_remontada_championship'), findsOneWidget);
+    expect(find.text('elite_remontada_championship'), findsOneWidget);
+    expect(find.text('champions_league_remontada_championship'), findsOneWidget);
   });
 
   testWidgets('league tab shows standings table', (tester) async {


### PR DESCRIPTION
## Summary
- add localization keys for championship cards
- implement reusable ChampionshipCard widget and specific championship cards
- display three championship cards in the challenges screen
- update translations for Arabic and English
- adjust widget tests to check championship tab

## Testing
- `flutter analyze`
- `flutter test`

------
https://chatgpt.com/codex/tasks/task_b_687dec3b07c4832c86dbdef5d90cb521