### PR TITLE
Update CreateTeamPage layout

### DIFF
--- a/assets/translations/ar-EG.json
+++ b/assets/translations/ar-EG.json
@@ -202,6 +202,7 @@
 "rounds_count":"عدد الجولات: {}",
 "available_to_join":"متاح للانضمام",
 "create_team_title":"إنشاء فريق جديد",
+"team_logo_section":"صورة وشعار الفريق",
 "team_add_image":"إضافة صورة",
 "team_info_section":"معلومات الفريق",
 "team_name_label":"اسم الفريق",

--- a/assets/translations/en-US.json
+++ b/assets/translations/en-US.json
@@ -192,6 +192,7 @@
   "rounds_count": "Rounds: {}",
   "available_to_join": "Available to Join",
   "create_team_title": "Create New Team",
+  "team_logo_section": "Team Logo",
   "team_add_image": "Add Image",
   "team_info_section": "Team Information",
   "team_name_label": "Team Name",

--- a/lib/core/app_strings/locale_keys.dart
+++ b/lib/core/app_strings/locale_keys.dart
@@ -248,6 +248,7 @@ abstract class LocaleKeys {
   static const league_goal_diff = 'league_goal_diff';
   static const league_points = 'league_points';
   static const create_team_title = 'create_team_title';
+  static const team_logo_section = 'team_logo_section';
   static const team_add_image = 'team_add_image';
   static const team_info_section = 'team_info_section';
   static const team_name_label = 'team_name_label';

--- a/lib/features/challenges/presentation/screens/create_team_page.dart
+++ b/lib/features/challenges/presentation/screens/create_team_page.dart
@@ -28,6 +28,7 @@ class _CreateTeamPageState extends State<CreateTeamPage> {
   }
 
   @override
+  /// Builds the full create team page UI.
   Widget build(BuildContext context) {
     const darkBlue = Color(0xFF23425F);
     return Scaffold(
@@ -61,39 +62,46 @@ class _CreateTeamPageState extends State<CreateTeamPage> {
           padding: const EdgeInsets.all(16),
           child: Directionality(
             textDirection: TextDirection.rtl,
-            child: Column(
-              crossAxisAlignment: CrossAxisAlignment.stretch,
-              children: [
-                GestureDetector(
-                  onTap: _pickLogo,
-                  child: Column(
-                    mainAxisSize: MainAxisSize.min,
-                    children: [
-                      Container(
-                        width: 100,
-                        height: 100,
-                        decoration: BoxDecoration(
-                          shape: BoxShape.circle,
-                          border: Border.all(color: darkBlue),
-                        ),
-                        child: _logo != null
-                            ? ClipOval(
-                                child: Image.file(
-                                  _logo!,
-                                  fit: BoxFit.cover,
-                                ),
-                              )
-                            : const Icon(Icons.camera_alt, color: darkBlue),
-                      ),
-                      const SizedBox(height: 8),
-                      CustomText(
-                        LocaleKeys.team_add_image.tr(),
-                        color: darkBlue,
-                      ),
-                    ],
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.stretch,
+                children: [
+                  CustomText(
+                    LocaleKeys.team_logo_section.tr(),
+                    color: darkBlue,
+                    weight: FontWeight.bold,
+                    align: TextAlign.right,
                   ),
-                ),
-                const SizedBox(height: 24),
+                  const SizedBox(height: 8),
+                  GestureDetector(
+                    onTap: _pickLogo,
+                    child: Column(
+                      mainAxisSize: MainAxisSize.min,
+                      children: [
+                        Container(
+                          width: 100,
+                          height: 100,
+                          decoration: BoxDecoration(
+                            shape: BoxShape.circle,
+                            border: Border.all(color: darkBlue),
+                          ),
+                          child: _logo != null
+                              ? ClipOval(
+                                  child: Image.file(
+                                    _logo!,
+                                    fit: BoxFit.cover,
+                                  ),
+                                )
+                              : const Icon(Icons.camera_alt, color: darkBlue),
+                        ),
+                        const SizedBox(height: 8),
+                        CustomText(
+                          LocaleKeys.team_add_image.tr(),
+                          color: darkBlue,
+                        ),
+                      ],
+                    ),
+                  ),
+                  const SizedBox(height: 24),
                 CustomText(
                   LocaleKeys.team_info_section.tr(),
                   color: darkBlue,
@@ -122,14 +130,27 @@ class _CreateTeamPageState extends State<CreateTeamPage> {
                   ),
                 ),
                 const SizedBox(height: 16),
+                Row(
+                  children: [
+                    const Icon(Icons.info_outline, color: darkBlue, size: 18),
+                    const SizedBox(width: 4),
+                    CustomText(
+                      LocaleKeys.team_level_label.tr(),
+                      color: darkBlue,
+                      weight: FontWeight.bold,
+                    ),
+                  ],
+                ),
+                const SizedBox(height: 8),
                 TextFormField(
                   enabled: false,
                   decoration: InputDecoration(
-                    labelText: LocaleKeys.team_level_label.tr(),
                     hintText: LocaleKeys.team_level_hint.tr(),
-                    suffixIcon: const Icon(Icons.info_outline),
+                    filled: true,
+                    fillColor: Colors.grey.shade200,
                     border: OutlineInputBorder(
                       borderRadius: BorderRadius.circular(12),
+                      borderSide: BorderSide.none,
                     ),
                   ),
                 ),

--- a/test/create_team_page_test.dart
+++ b/test/create_team_page_test.dart
@@ -1,0 +1,14 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:remontada/features/challenges/presentation/screens/create_team_page.dart';
+
+void main() {
+  testWidgets('CreateTeamPage layout displays all sections', (tester) async {
+    await tester.pumpWidget(const MaterialApp(home: CreateTeamPage()));
+    await tester.pumpAndSettle();
+
+    expect(find.byIcon(Icons.arrow_back_ios), findsOneWidget);
+    expect(find.text('team_logo_section'), findsOneWidget);
+    expect(find.text('team_info_section'), findsOneWidget);
+  });
+}


### PR DESCRIPTION
## Summary
- style CreateTeamPage to include team logo section and updated team level field
- support new `team_logo_section` translation key
- add widget test covering new layout

## Testing
- `ruff check .`
- `pytest -q`
- `flutter test test/create_team_page_test.dart`
- `flutter test`

------
https://chatgpt.com/codex/tasks/task_b_687df879305c832c8d7b19e1cdfdec00