### PR TITLE
Add coaching staff section to CreateTeamPage

### DIFF
--- a/assets/translations/ar-EG.json
+++ b/assets/translations/ar-EG.json
@@ -211,5 +211,16 @@
 "team_description_hint":"أدخل وصف بسيط للفريق",
 "team_level_label":"مستوى الفريق",
 "team_level_hint":"سيتم تحديده لاحقًا",
-"team_level_note":"ملاحظة: سيتم تحديد مستوى الفريق تلقائيًا بناءً على نتائج المباريات والأداء العام للفريق"
+"team_level_note":"ملاحظة: سيتم تحديد مستوى الفريق تلقائيًا بناءً على نتائج المباريات والأداء العام للفريق",
+"coaching_staff_section":"الجهاز الفني",
+"coach_title":"المدرب",
+"coach_name_label":"اسم المدرب",
+"coach_name_hint":"أدخل اسم المدرب",
+"coach_phone_label":"رقم هاتف المدرب",
+"coach_phone_hint":"أدخل رقم الهاتف",
+"assistant_title":"المساعد",
+"assistant_name_label":"اسم المساعد",
+"assistant_name_hint":"أدخل اسم المساعد",
+"assistant_phone_label":"رقم هاتف المساعد",
+"assistant_phone_hint":"أدخل رقم الهاتف"
 }

--- a/assets/translations/en-US.json
+++ b/assets/translations/en-US.json
@@ -201,5 +201,16 @@
   "team_description_hint": "Enter a short description",
   "team_level_label": "Team Level",
   "team_level_hint": "Will be determined later",
-  "team_level_note": "Note: Team level will be automatically determined based on match results and overall team performance"
+  "team_level_note": "Note: Team level will be automatically determined based on match results and overall team performance",
+  "coaching_staff_section": "Coaching Staff",
+  "coach_title": "Coach",
+  "coach_name_label": "Coach Name",
+  "coach_name_hint": "Enter coach name",
+  "coach_phone_label": "Coach Phone",
+  "coach_phone_hint": "Enter phone number",
+  "assistant_title": "Assistant",
+  "assistant_name_label": "Assistant Name",
+  "assistant_name_hint": "Enter assistant name",
+  "assistant_phone_label": "Assistant Phone",
+  "assistant_phone_hint": "Enter phone number"
 }

--- a/lib/core/app_strings/locale_keys.dart
+++ b/lib/core/app_strings/locale_keys.dart
@@ -258,4 +258,15 @@ abstract class LocaleKeys {
   static const team_level_label = 'team_level_label';
   static const team_level_hint = 'team_level_hint';
   static const team_level_note = 'team_level_note';
+  static const coaching_staff_section = 'coaching_staff_section';
+  static const coach_title = 'coach_title';
+  static const coach_name_label = 'coach_name_label';
+  static const coach_name_hint = 'coach_name_hint';
+  static const coach_phone_label = 'coach_phone_label';
+  static const coach_phone_hint = 'coach_phone_hint';
+  static const assistant_title = 'assistant_title';
+  static const assistant_name_label = 'assistant_name_label';
+  static const assistant_name_hint = 'assistant_name_hint';
+  static const assistant_phone_label = 'assistant_phone_label';
+  static const assistant_phone_hint = 'assistant_phone_hint';
 }

--- a/lib/features/challenges/presentation/screens/create_team_page.dart
+++ b/lib/features/challenges/presentation/screens/create_team_page.dart
@@ -167,6 +167,124 @@ class _CreateTeamPageState extends State<CreateTeamPage> {
                     color: Colors.black54,
                   ),
                 ),
+                const SizedBox(height: 24),
+                Row(
+                  children: [
+                    const Icon(Icons.groups_2, color: darkBlue),
+                    const SizedBox(width: 4),
+                    CustomText(
+                      LocaleKeys.coaching_staff_section.tr(),
+                      color: darkBlue,
+                      weight: FontWeight.bold,
+                    ),
+                  ],
+                ),
+                const SizedBox(height: 12),
+                Column(
+                  children: [
+                    Container(
+                      padding: const EdgeInsets.all(12),
+                      decoration: BoxDecoration(
+                        color: Colors.grey.shade100,
+                        borderRadius: BorderRadius.circular(12),
+                        boxShadow: [
+                          BoxShadow(
+                            color: Colors.black12,
+                            blurRadius: 4,
+                            offset: Offset(0, 2),
+                          ),
+                        ],
+                      ),
+                      child: Column(
+                        crossAxisAlignment: CrossAxisAlignment.stretch,
+                        children: [
+                          Row(
+                            children: [
+                              const Icon(Icons.person, size: 18, color: darkBlue),
+                              const SizedBox(width: 4),
+                              CustomText(
+                                LocaleKeys.coach_title.tr(),
+                                color: darkBlue,
+                                weight: FontWeight.bold,
+                              ),
+                            ],
+                          ),
+                          const SizedBox(height: 8),
+                          TextFormField(
+                            decoration: InputDecoration(
+                              labelText: LocaleKeys.coach_name_label.tr(),
+                              hintText: LocaleKeys.coach_name_hint.tr(),
+                              border: OutlineInputBorder(
+                                borderRadius: BorderRadius.circular(12),
+                              ),
+                            ),
+                          ),
+                          const SizedBox(height: 12),
+                          TextFormField(
+                            decoration: InputDecoration(
+                              labelText: LocaleKeys.coach_phone_label.tr(),
+                              hintText: LocaleKeys.coach_phone_hint.tr(),
+                              border: OutlineInputBorder(
+                                borderRadius: BorderRadius.circular(12),
+                              ),
+                            ),
+                          ),
+                        ],
+                      ),
+                    ),
+                    const SizedBox(height: 12),
+                    Container(
+                      padding: const EdgeInsets.all(12),
+                      decoration: BoxDecoration(
+                        color: Colors.grey.shade100,
+                        borderRadius: BorderRadius.circular(12),
+                        boxShadow: [
+                          BoxShadow(
+                            color: Colors.black12,
+                            blurRadius: 4,
+                            offset: Offset(0, 2),
+                          ),
+                        ],
+                      ),
+                      child: Column(
+                        crossAxisAlignment: CrossAxisAlignment.stretch,
+                        children: [
+                          Row(
+                            children: [
+                              const Icon(Icons.person, size: 18, color: darkBlue),
+                              const SizedBox(width: 4),
+                              CustomText(
+                                LocaleKeys.assistant_title.tr(),
+                                color: darkBlue,
+                                weight: FontWeight.bold,
+                              ),
+                            ],
+                          ),
+                          const SizedBox(height: 8),
+                          TextFormField(
+                            decoration: InputDecoration(
+                              labelText: LocaleKeys.assistant_name_label.tr(),
+                              hintText: LocaleKeys.assistant_name_hint.tr(),
+                              border: OutlineInputBorder(
+                                borderRadius: BorderRadius.circular(12),
+                              ),
+                            ),
+                          ),
+                          const SizedBox(height: 12),
+                          TextFormField(
+                            decoration: InputDecoration(
+                              labelText: LocaleKeys.assistant_phone_label.tr(),
+                              hintText: LocaleKeys.assistant_phone_hint.tr(),
+                              border: OutlineInputBorder(
+                                borderRadius: BorderRadius.circular(12),
+                              ),
+                            ),
+                          ),
+                        ],
+                      ),
+                    ),
+                  ],
+                ),
               ],
             ),
           ),

--- a/test/create_team_page_test.dart
+++ b/test/create_team_page_test.dart
@@ -10,5 +10,6 @@ void main() {
     expect(find.byIcon(Icons.arrow_back_ios), findsOneWidget);
     expect(find.text('team_logo_section'), findsOneWidget);
     expect(find.text('team_info_section'), findsOneWidget);
+    expect(find.text('coaching_staff_section'), findsOneWidget);
   });
 }


### PR DESCRIPTION
## Summary
- localize coach/assistant labels and hints
- generate locale keys for new fields
- extend CreateTeamPage with "الجهاز الفني" section
- verify layout via unit test

## Testing
- `flutter test`
- `ruff check .`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_b_687e007f3190832ca1ea43ad1d38ece1