### PR TITLE
Add invite member options to CreateTeamPage

### DIFF
--- a/assets/translations/ar-EG.json
+++ b/assets/translations/ar-EG.json
@@ -233,5 +233,15 @@
 "player_number_label":"رقم القميص",
 "player_number_hint":"رقم",
 "player_phone_label":"رقم الهاتف",
-"player_phone_hint":"أدخل رقم الهاتف"
+"player_phone_hint":"أدخل رقم الهاتف",
+"add_new_player":"إضافة لاعب جديد",
+"invite_members_section":"دعوة الأعضاء",
+"enable_invite_title":"تفعيل دعوة الأعضاء",
+"enable_invite_subtitle":"السماح بدعوة اللاعبين عبر منصات التواصل الاجتماعي",
+"choose_social_platforms_label":"اختر منصات التواصل:",
+"social_whatsapp":"واتساب",
+"social_telegram":"تيليجرام",
+"social_instagram":"إنستجرام",
+"social_twitter":"تويتر",
+"create_team_button":"إنشاء الفريق"
 }

--- a/assets/translations/en-US.json
+++ b/assets/translations/en-US.json
@@ -223,5 +223,15 @@
   "player_number_label": "Jersey Number",
   "player_number_hint": "Number",
   "player_phone_label": "Phone Number",
-  "player_phone_hint": "Enter phone number"
+  "player_phone_hint": "Enter phone number",
+  "add_new_player": "Add New Player",
+  "invite_members_section": "Invite Members",
+  "enable_invite_title": "Enable Member Invites",
+  "enable_invite_subtitle": "Allow inviting players via social platforms",
+  "choose_social_platforms_label": "Choose social platforms:",
+  "social_whatsapp": "WhatsApp",
+  "social_telegram": "Telegram",
+  "social_instagram": "Instagram",
+  "social_twitter": "Twitter",
+  "create_team_button": "Create Team"
 }

--- a/lib/core/app_strings/locale_keys.dart
+++ b/lib/core/app_strings/locale_keys.dart
@@ -280,4 +280,14 @@ abstract class LocaleKeys {
   static const player_number_hint = 'player_number_hint';
   static const player_phone_label = 'player_phone_label';
   static const player_phone_hint = 'player_phone_hint';
+  static const add_new_player = 'add_new_player';
+  static const invite_members_section = 'invite_members_section';
+  static const enable_invite_title = 'enable_invite_title';
+  static const enable_invite_subtitle = 'enable_invite_subtitle';
+  static const choose_social_platforms_label = 'choose_social_platforms_label';
+  static const social_whatsapp = 'social_whatsapp';
+  static const social_telegram = 'social_telegram';
+  static const social_instagram = 'social_instagram';
+  static const social_twitter = 'social_twitter';
+  static const create_team_button = 'create_team_button';
 }

--- a/lib/features/challenges/presentation/screens/create_team_page.dart
+++ b/lib/features/challenges/presentation/screens/create_team_page.dart
@@ -6,6 +6,7 @@ import 'package:flutter/material.dart';
 import '../../../../core/app_strings/locale_keys.dart';
 import '../../../../core/services/media/my_media.dart';
 import '../../../../shared/widgets/customtext.dart';
+import 'package:font_awesome_flutter/font_awesome_flutter.dart';
 
 /// Page allowing users to create a new team.
 class CreateTeamPage extends StatefulWidget {
@@ -18,6 +19,38 @@ class CreateTeamPage extends StatefulWidget {
 
 class _CreateTeamPageState extends State<CreateTeamPage> {
   File? _logo;
+  bool _inviteEnabled = false;
+  final Set<String> _selectedPlatforms = {};
+
+  /// Builds a choice chip for selecting a social platform.
+  Widget _buildSocialChip(String key, IconData icon, String label) {
+    const darkBlue = Color(0xFF23425F);
+    final selected = _selectedPlatforms.contains(key);
+    return ChoiceChip(
+      label: Row(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          Icon(icon, size: 16, color: selected ? Colors.white : darkBlue),
+          const SizedBox(width: 4),
+          CustomText(label, color: selected ? Colors.white : darkBlue),
+        ],
+      ),
+      selected: selected,
+      onSelected: (val) {
+        setState(() {
+          if (val) {
+            _selectedPlatforms.add(key);
+          } else {
+            _selectedPlatforms.remove(key);
+          }
+        });
+      },
+      backgroundColor: Colors.grey.shade200,
+      selectedColor: darkBlue,
+      shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(20)),
+      labelPadding: const EdgeInsets.symmetric(horizontal: 8),
+    );
+  }
 
   /// Picks an image from the gallery and updates the logo state.
   Future<void> _pickLogo() async {
@@ -433,6 +466,105 @@ class _CreateTeamPageState extends State<CreateTeamPage> {
                 ),
                 const SizedBox(height: 12),
                 _buildPlayerCard(1),
+                const SizedBox(height: 16),
+                SizedBox(
+                  width: double.infinity,
+                  child: OutlinedButton.icon(
+                    onPressed: () {},
+                    icon: const Icon(Icons.add, color: darkBlue),
+                    label: CustomText(
+                      LocaleKeys.add_new_player.tr(),
+                      color: darkBlue,
+                      weight: FontWeight.bold,
+                    ),
+                    style: OutlinedButton.styleFrom(
+                      backgroundColor: Colors.grey.shade100,
+                      side: const BorderSide(color: darkBlue),
+                      shape: RoundedRectangleBorder(
+                        borderRadius: BorderRadius.circular(30),
+                      ),
+                    ),
+                  ),
+                ),
+                const SizedBox(height: 24),
+                Row(
+                  children: [
+                    const Icon(Icons.share, color: darkBlue),
+                    const SizedBox(width: 4),
+                    CustomText(
+                      LocaleKeys.invite_members_section.tr(),
+                      color: darkBlue,
+                      weight: FontWeight.bold,
+                    ),
+                  ],
+                ),
+                const SizedBox(height: 12),
+                SwitchListTile(
+                  value: _inviteEnabled,
+                  onChanged: (val) => setState(() => _inviteEnabled = val),
+                  contentPadding: EdgeInsets.zero,
+                  title: CustomText(
+                    LocaleKeys.enable_invite_title.tr(),
+                    color: darkBlue,
+                    weight: FontWeight.bold,
+                  ),
+                  subtitle: CustomText(
+                    LocaleKeys.enable_invite_subtitle.tr(),
+                    color: Colors.black54,
+                  ),
+                  activeColor: darkBlue,
+                ),
+                const SizedBox(height: 12),
+                CustomText(
+                  LocaleKeys.choose_social_platforms_label.tr(),
+                  color: darkBlue,
+                  weight: FontWeight.bold,
+                ),
+                const SizedBox(height: 8),
+                Wrap(
+                  spacing: 8,
+                  children: [
+                    _buildSocialChip(
+                      'whatsapp',
+                      FontAwesomeIcons.whatsapp,
+                      LocaleKeys.social_whatsapp.tr(),
+                    ),
+                    _buildSocialChip(
+                      'telegram',
+                      FontAwesomeIcons.telegram,
+                      LocaleKeys.social_telegram.tr(),
+                    ),
+                    _buildSocialChip(
+                      'instagram',
+                      FontAwesomeIcons.instagram,
+                      LocaleKeys.social_instagram.tr(),
+                    ),
+                    _buildSocialChip(
+                      'twitter',
+                      FontAwesomeIcons.twitter,
+                      LocaleKeys.social_twitter.tr(),
+                    ),
+                  ],
+                ),
+                const SizedBox(height: 24),
+                SizedBox(
+                  width: double.infinity,
+                  child: ElevatedButton(
+                    onPressed: () {},
+                    style: ElevatedButton.styleFrom(
+                      backgroundColor: darkBlue,
+                      shape: RoundedRectangleBorder(
+                        borderRadius: BorderRadius.circular(30),
+                      ),
+                      padding: const EdgeInsets.symmetric(vertical: 16),
+                    ),
+                    child: CustomText(
+                      LocaleKeys.create_team_button.tr(),
+                      color: Colors.white,
+                      weight: FontWeight.bold,
+                    ),
+                  ),
+                ),
               ],
             ),
           ),

--- a/test/create_team_page_test.dart
+++ b/test/create_team_page_test.dart
@@ -12,5 +12,10 @@ void main() {
     expect(find.text('team_info_section'), findsOneWidget);
     expect(find.text('coaching_staff_section'), findsOneWidget);
     expect(find.text('players_list_section'), findsOneWidget);
+    expect(find.text('add_new_player'), findsOneWidget);
+    expect(find.text('invite_members_section'), findsOneWidget);
+    expect(find.text('enable_invite_title'), findsOneWidget);
+    expect(find.text('choose_social_platforms_label'), findsOneWidget);
+    expect(find.text('create_team_button'), findsOneWidget);
   });
 }


### PR DESCRIPTION
## Summary
- extend `CreateTeamPage` with extra invite member widgets
- localize new strings in Arabic and English
- expose new locale keys
- verify layout through updated widget test

## Testing
- `pytest -q`
- `ruff check .`

------
https://chatgpt.com/codex/tasks/task_b_687e22cf6458832cbef12493463ac346