### PR TITLE
Add manage team widget to Challenges screen

### DIFF
--- a/assets/translations/ar-EG.json
+++ b/assets/translations/ar-EG.json
@@ -173,6 +173,7 @@
 "challenge_more":"المزيد",
 "challenge_updates":"التحديات",
 "challenge_create_team":"إنشاء فريق",
+"manage_your_team":"إدارة فريقك",
 "challenge_create_challenge":"إنشاء تحدي جديد",
 "league_schedule":"جدول الدوري",
 "championships":"البطولات",

--- a/assets/translations/en-US.json
+++ b/assets/translations/en-US.json
@@ -163,6 +163,7 @@
 "challenge_more": "More",
 "challenge_updates": "Challanges",
   "challenge_create_team": "Create Team",
+  "manage_your_team": "Manage Your Team",
   "challenge_create_challenge": "Create New Challenge",
   "league_schedule": "League Schedule",
   "championships": "Championships",

--- a/lib/core/app_strings/locale_keys.dart
+++ b/lib/core/app_strings/locale_keys.dart
@@ -216,6 +216,7 @@ abstract class LocaleKeys {
   static const challenge_more = 'challenge_more';
   static const challenge_updates = 'challenge_updates';
   static const challenge_create_team = 'challenge_create_team';
+  static const manage_your_team = 'manage_your_team';
   static const challenge_create_challenge = 'challenge_create_challenge';
   static const league_schedule = 'league_schedule';
   static const championships = 'championships';

--- a/lib/features/challenges/presentation/screens/challenges_screen.dart
+++ b/lib/features/challenges/presentation/screens/challenges_screen.dart
@@ -676,6 +676,54 @@ class _ChallengesScreenState extends State<ChallengesScreen>
     );
   }
 
+  /// Displays a row with a manage team button, team name and a groups icon.
+  Widget _manageTeamRow() {
+    const darkBlue = Color(0xFF23425F);
+    return Directionality(
+      textDirection: TextDirection.rtl,
+      child: Padding(
+        padding: const EdgeInsets.symmetric(vertical: 8),
+        child: Row(
+          mainAxisAlignment: MainAxisAlignment.spaceBetween,
+          children: [
+            Container(
+              height: 36,
+              padding: const EdgeInsets.symmetric(horizontal: 12),
+              decoration: BoxDecoration(
+                color: darkBlue,
+                borderRadius: BorderRadius.circular(8),
+              ),
+              child: Center(
+                child: Text(
+                  LocaleKeys.manage_your_team.tr(),
+                  style: const TextStyle(
+                    color: Colors.white,
+                    fontWeight: FontWeight.bold,
+                  ),
+                ),
+              ),
+            ),
+            Expanded(
+              child: Center(
+                child: Text(
+                  'ريـمونتادا',
+                  style: const TextStyle(
+                    color: darkBlue,
+                    fontWeight: FontWeight.bold,
+                  ),
+                ),
+              ),
+            ),
+            CircleAvatar(
+              backgroundColor: darkBlue,
+              child: const Icon(Icons.groups, color: Colors.white),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+
   @override
   Widget build(BuildContext context) {
     const darkBlue = Color(0xFF23425F);
@@ -736,6 +784,7 @@ class _ChallengesScreenState extends State<ChallengesScreen>
               ),
               const SizedBox(height: 16),
               _buildCarousel(),
+              _manageTeamRow(),
               18.ph,
               Directionality(
                 textDirection: TextDirection.rtl,

--- a/test/challenges_screen_test.dart
+++ b/test/challenges_screen_test.dart
@@ -31,6 +31,20 @@ void main() {
     expect(find.byType(CarouselSlider), findsOneWidget);
   });
 
+  testWidgets('manage team row is displayed', (tester) async {
+    tester.binding.window.physicalSizeTestValue = const Size(1200, 800);
+    tester.binding.window.devicePixelRatioTestValue = 1.0;
+    addTearDown(() {
+      tester.binding.window.clearPhysicalSizeTestValue();
+      tester.binding.window.clearDevicePixelRatioTestValue();
+    });
+    await tester.pumpWidget(const MaterialApp(home: ChallengesScreen()));
+    await tester.pumpAndSettle();
+    expect(find.text('manage_your_team'), findsOneWidget);
+    expect(find.text('ريـمونتادا'), findsOneWidget);
+    expect(find.byIcon(Icons.groups), findsOneWidget);
+  });
+
   testWidgets('first tab shows challenge cards', (tester) async {
     tester.binding.window.physicalSizeTestValue = const Size(1200, 800);
     tester.binding.window.devicePixelRatioTestValue = 1.0;


### PR DESCRIPTION
## Summary
- introduce a manage team row on ChallengesScreen
- localize new `manage_your_team` string
- test for new manage team row

## Testing
- `flutter test`
- `pytest`
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_b_687e281fd668832cbf41e1cc8572f230