### PR TITLE
Add TeamDetailsPage with navigation

### DIFF
--- a/assets/translations/ar-EG.json
+++ b/assets/translations/ar-EG.json
@@ -244,5 +244,10 @@
 "social_telegram":"تيليجرام",
 "social_instagram":"إنستجرام",
 "social_twitter":"تويتر",
-"create_team_button":"إنشاء الفريق"
+"create_team_button":"إنشاء الفريق",
+"team_details_info":"المعلومات",
+"team_details_members":"الأعضاء",
+"team_details_join":"الانضمام",
+"team_details_transfer":"الانتقال",
+"team_details_chat":"الدردشة"
 }

--- a/assets/translations/en-US.json
+++ b/assets/translations/en-US.json
@@ -234,5 +234,10 @@
   "social_telegram": "Telegram",
   "social_instagram": "Instagram",
   "social_twitter": "Twitter",
-  "create_team_button": "Create Team"
+  "create_team_button": "Create Team",
+  "team_details_info": "Info",
+  "team_details_members": "Members",
+  "team_details_join": "Join",
+  "team_details_transfer": "Transfer",
+  "team_details_chat": "Chat"
 }

--- a/lib/core/app_strings/locale_keys.dart
+++ b/lib/core/app_strings/locale_keys.dart
@@ -291,4 +291,9 @@ abstract class LocaleKeys {
   static const social_instagram = 'social_instagram';
   static const social_twitter = 'social_twitter';
   static const create_team_button = 'create_team_button';
+  static const team_details_info = 'team_details_info';
+  static const team_details_members = 'team_details_members';
+  static const team_details_join = 'team_details_join';
+  static const team_details_transfer = 'team_details_transfer';
+  static const team_details_chat = 'team_details_chat';
 }

--- a/lib/features/challenges/presentation/screens/challenges_screen.dart
+++ b/lib/features/challenges/presentation/screens/challenges_screen.dart
@@ -8,6 +8,7 @@ import 'package:remontada/features/home/presentation/widgets/custom_dots.dart';
 import 'package:remontada/shared/widgets/customtext.dart';
 import '../widgets/championship_card.dart';
 import 'create_team_page.dart';
+import 'team_details_page.dart';
 
 /// Placeholder screen shown for the upcoming Challenges feature.
 class ChallengesScreen extends StatefulWidget {
@@ -709,7 +710,14 @@ class _ChallengesScreenState extends State<ChallengesScreen>
             SizedBox(
               height: 36,
               child: ElevatedButton(
-                onPressed: () {},
+                onPressed: () {
+                  Navigator.push(
+                    context,
+                    MaterialPageRoute(
+                      builder: (_) => const TeamDetailsPage(),
+                    ),
+                  );
+                },
                 style: ElevatedButton.styleFrom(
                   backgroundColor: darkBlue,
                   minimumSize: const Size(120, 36),

--- a/lib/features/challenges/presentation/screens/team_details_page.dart
+++ b/lib/features/challenges/presentation/screens/team_details_page.dart
@@ -1,0 +1,54 @@
+import 'package:flutter/material.dart';
+import 'package:easy_localization/easy_localization.dart' hide TextDirection;
+import '../../../../core/app_strings/locale_keys.dart';
+
+/// Displays detailed information about a team using a tab bar styled as a
+/// bottom navigation bar.
+class TeamDetailsPage extends StatelessWidget {
+  /// Creates a new [TeamDetailsPage].
+  const TeamDetailsPage({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    const darkBlue = Color(0xFF23425F);
+    return DefaultTabController(
+      length: 5,
+      child: Directionality(
+        textDirection: TextDirection.rtl,
+        child: Scaffold(
+          appBar: AppBar(
+            title: Text(LocaleKeys.manage_your_team.tr()),
+          ),
+          body: const TabBarView(
+            physics: NeverScrollableScrollPhysics(),
+            children: [
+              Center(child: Text(LocaleKeys.team_details_info)),
+              Center(child: Text(LocaleKeys.team_details_members)),
+              Center(child: Text(LocaleKeys.team_details_join)),
+              Center(child: Text(LocaleKeys.team_details_transfer)),
+              Center(child: Text(LocaleKeys.team_details_chat)),
+            ],
+          ),
+          bottomNavigationBar: Container(
+            decoration: const BoxDecoration(
+              border: Border(top: BorderSide(color: Colors.grey)),
+            ),
+            child: TabBar(
+              indicatorColor: darkBlue,
+              labelColor: darkBlue,
+              unselectedLabelColor: Colors.grey,
+              indicatorWeight: 3,
+              tabs: const [
+                Tab(icon: Icon(Icons.info), text: LocaleKeys.team_details_info),
+                Tab(icon: Icon(Icons.groups), text: LocaleKeys.team_details_members),
+                Tab(icon: Icon(Icons.person_add), text: LocaleKeys.team_details_join),
+                Tab(icon: Icon(Icons.transfer_within_a_station), text: LocaleKeys.team_details_transfer),
+                Tab(icon: Icon(Icons.chat), text: LocaleKeys.team_details_chat),
+              ],
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/test/challenges_screen_test.dart
+++ b/test/challenges_screen_test.dart
@@ -153,4 +153,18 @@ void main() {
     await tester.pumpAndSettle();
     expect(find.text('create_team_title'), findsOneWidget);
   });
+
+  testWidgets('tapping manage team navigates to TeamDetailsPage', (tester) async {
+    tester.binding.window.physicalSizeTestValue = const Size(1200, 800);
+    tester.binding.window.devicePixelRatioTestValue = 1.0;
+    addTearDown(() {
+      tester.binding.window.clearPhysicalSizeTestValue();
+      tester.binding.window.clearDevicePixelRatioTestValue();
+    });
+    await tester.pumpWidget(const MaterialApp(home: ChallengesScreen()));
+    await tester.pumpAndSettle();
+    await tester.tap(find.widgetWithText(ElevatedButton, 'manage_your_team'));
+    await tester.pumpAndSettle();
+    expect(find.text('team_details_info'), findsWidgets);
+  });
 }


### PR DESCRIPTION
## Summary
- add tabbed `TeamDetailsPage`
- navigate to the new page from `ChallengesScreen` manage team button
- localize new tab labels
- test navigation to new page

## Testing
- `flutter analyze`
- `flutter test`
- `pytest`
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_b_687e355facc4832ca5f4d5237900479c