### PR TITLE
Fix TeamDetailsPage translations

### DIFF
--- a/lib/features/challenges/presentation/screens/team_details_page.dart
+++ b/lib/features/challenges/presentation/screens/team_details_page.dart
@@ -19,14 +19,14 @@ class TeamDetailsPage extends StatelessWidget {
           appBar: AppBar(
             title: Text(LocaleKeys.manage_your_team.tr()),
           ),
-          body: const TabBarView(
-            physics: NeverScrollableScrollPhysics(),
+          body: TabBarView(
+            physics: const NeverScrollableScrollPhysics(),
             children: [
-              Center(child: Text(LocaleKeys.team_details_info)),
-              Center(child: Text(LocaleKeys.team_details_members)),
-              Center(child: Text(LocaleKeys.team_details_join)),
-              Center(child: Text(LocaleKeys.team_details_transfer)),
-              Center(child: Text(LocaleKeys.team_details_chat)),
+              Center(child: Text(LocaleKeys.team_details_info.tr())),
+              Center(child: Text(LocaleKeys.team_details_members.tr())),
+              Center(child: Text(LocaleKeys.team_details_join.tr())),
+              Center(child: Text(LocaleKeys.team_details_transfer.tr())),
+              Center(child: Text(LocaleKeys.team_details_chat.tr())),
             ],
           ),
           bottomNavigationBar: Container(
@@ -38,12 +38,12 @@ class TeamDetailsPage extends StatelessWidget {
               labelColor: darkBlue,
               unselectedLabelColor: Colors.grey,
               indicatorWeight: 3,
-              tabs: const [
-                Tab(icon: Icon(Icons.info), text: LocaleKeys.team_details_info),
-                Tab(icon: Icon(Icons.groups), text: LocaleKeys.team_details_members),
-                Tab(icon: Icon(Icons.person_add), text: LocaleKeys.team_details_join),
-                Tab(icon: Icon(Icons.transfer_within_a_station), text: LocaleKeys.team_details_transfer),
-                Tab(icon: Icon(Icons.chat), text: LocaleKeys.team_details_chat),
+              tabs: [
+                Tab(icon: const Icon(Icons.info), text: LocaleKeys.team_details_info.tr()),
+                Tab(icon: const Icon(Icons.groups), text: LocaleKeys.team_details_members.tr()),
+                Tab(icon: const Icon(Icons.person_add), text: LocaleKeys.team_details_join.tr()),
+                Tab(icon: const Icon(Icons.transfer_within_a_station), text: LocaleKeys.team_details_transfer.tr()),
+                Tab(icon: const Icon(Icons.chat), text: LocaleKeys.team_details_chat.tr()),
               ],
             ),
           ),

--- a/test/challenges_screen_test.dart
+++ b/test/challenges_screen_test.dart
@@ -2,9 +2,13 @@ import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:carousel_slider/carousel_slider.dart';
 import 'package:remontada/features/challenges/presentation/screens/challenges_screen.dart';
+import 'package:easy_localization/easy_localization.dart';
+import 'package:shared_preferences/shared_preferences.dart';
 
-void main() {
+void main() async {
   TestWidgetsFlutterBinding.ensureInitialized();
+  SharedPreferences.setMockInitialValues({});
+  await EasyLocalization.ensureInitialized();
 
   testWidgets('challenge screen shows header icons', (tester) async {
     tester.binding.window.physicalSizeTestValue = const Size(1200, 800);
@@ -161,10 +165,24 @@ void main() {
       tester.binding.window.clearPhysicalSizeTestValue();
       tester.binding.window.clearDevicePixelRatioTestValue();
     });
-    await tester.pumpWidget(const MaterialApp(home: ChallengesScreen()));
+    await tester.pumpWidget(
+      EasyLocalization(
+        supportedLocales: const [Locale('en', 'US')],
+        path: 'assets/translations',
+        fallbackLocale: const Locale('en', 'US'),
+        child: Builder(
+          builder: (context) => MaterialApp(
+            locale: context.locale,
+            localizationsDelegates: context.localizationDelegates,
+            supportedLocales: context.supportedLocales,
+            home: const ChallengesScreen(),
+          ),
+        ),
+      ),
+    );
     await tester.pumpAndSettle();
-    await tester.tap(find.widgetWithText(ElevatedButton, 'manage_your_team'));
+    await tester.tap(find.widgetWithText(ElevatedButton, 'Manage Your Team'));
     await tester.pumpAndSettle();
-    expect(find.text('team_details_info'), findsWidgets);
+    expect(find.text('Info'), findsWidgets);
   });
 }


### PR DESCRIPTION
## Summary
- ensure TeamDetailsPage shows translated tab text
- wrap localization in tests to verify translation

## Testing
- `flutter analyze`
- `flutter test`

------
https://chatgpt.com/codex/tasks/task_b_687e39b5ab70832cb24b3ae01e0c5a30