### PR TITLE
Add Team info tab widgets

### DIFF
--- a/lib/features/challenges/presentation/screens/team_details_page.dart
+++ b/lib/features/challenges/presentation/screens/team_details_page.dart
@@ -22,7 +22,19 @@ class TeamDetailsPage extends StatelessWidget {
           body: TabBarView(
             physics: const NeverScrollableScrollPhysics(),
             children: [
-              Center(child: Text(LocaleKeys.team_details_info.tr())),
+              // Info tab content.
+              SingleChildScrollView(
+                padding: const EdgeInsets.all(16),
+                child: Column(
+                  children: const [
+                    _TopBar(),
+                    SizedBox(height: 16),
+                    _TeamSummaryCard(),
+                    SizedBox(height: 16),
+                    _AchievementsSection(),
+                  ],
+                ),
+              ),
               Center(child: Text(LocaleKeys.team_details_members.tr())),
               Center(child: Text(LocaleKeys.team_details_join.tr())),
               Center(child: Text(LocaleKeys.team_details_transfer.tr())),
@@ -48,6 +60,205 @@ class TeamDetailsPage extends StatelessWidget {
             ),
           ),
         ),
+      ),
+    );
+  }
+}
+
+/// Top bar showing settings icon, team name and forward arrow.
+class _TopBar extends StatelessWidget {
+  /// Creates a const [_TopBar].
+  const _TopBar();
+
+  @override
+  Widget build(BuildContext context) {
+    const darkBlue = Color(0xFF23425F);
+    return Padding(
+      padding: const EdgeInsets.symmetric(horizontal: 16.0),
+      child: Row(
+        mainAxisAlignment: MainAxisAlignment.spaceBetween,
+        children: const [
+          Icon(Icons.settings, color: darkBlue),
+          Text(
+            'ريـمونتادا',
+            style: TextStyle(
+              color: darkBlue,
+              fontWeight: FontWeight.bold,
+              fontSize: 18,
+            ),
+          ),
+          Icon(Icons.arrow_forward_ios, color: darkBlue),
+        ],
+      ),
+    );
+  }
+}
+
+/// Card displaying a summary about the team.
+class _TeamSummaryCard extends StatelessWidget {
+  /// Creates a const [_TeamSummaryCard].
+  const _TeamSummaryCard();
+
+  @override
+  Widget build(BuildContext context) {
+    const darkBlue = Color(0xFF23425F);
+    return Container(
+      padding: const EdgeInsets.all(16),
+      decoration: BoxDecoration(
+        color: darkBlue,
+        borderRadius: BorderRadius.circular(12),
+      ),
+      child: Column(
+        children: [
+          const Icon(Icons.sports_soccer, color: Colors.white, size: 40),
+          const SizedBox(height: 8),
+          const Text(
+            'ريـمونتادا',
+            style: TextStyle(
+              color: Colors.white,
+              fontWeight: FontWeight.bold,
+            ),
+          ),
+          const SizedBox(height: 4),
+          const Text(
+            'فريق يبحث عن التحديات و الصراعات الكوراوويه',
+            style: TextStyle(color: Colors.white),
+            textAlign: TextAlign.center,
+          ),
+          const SizedBox(height: 12),
+          Row(
+            mainAxisAlignment: MainAxisAlignment.spaceEvenly,
+            children: const [
+              _TeamStatItem(number: '10', label: 'اللاعبين'),
+              _TeamStatItem(number: '15', label: 'المباريات'),
+              _TeamStatItem(number: '12', label: 'الانتصارات'),
+            ],
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+/// Simple column displaying a number with a label.
+class _TeamStatItem extends StatelessWidget {
+  /// Stat number to display.
+  final String number;
+
+  /// Label for the stat.
+  final String label;
+
+  /// Creates a const [_TeamStatItem].
+  const _TeamStatItem({required this.number, required this.label});
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      children: [
+        Text(
+          number,
+          style: const TextStyle(
+            color: Colors.white,
+            fontWeight: FontWeight.bold,
+          ),
+        ),
+        Text(
+          label,
+          style: const TextStyle(color: Colors.white),
+        ),
+      ],
+    );
+  }
+}
+
+/// Section showing the achievements and badges for the team.
+class _AchievementsSection extends StatelessWidget {
+  /// Creates a const [_AchievementsSection].
+  const _AchievementsSection();
+
+  @override
+  Widget build(BuildContext context) {
+    const darkBlue = Color(0xFF23425F);
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Row(
+          mainAxisAlignment: MainAxisAlignment.start,
+          children: const [
+            Text(
+              'الأوسمة والإنجازات',
+              style: TextStyle(
+                fontWeight: FontWeight.bold,
+                fontSize: 16,
+                color: darkBlue,
+              ),
+            ),
+            SizedBox(width: 8),
+            Icon(Icons.emoji_events, color: darkBlue),
+          ],
+        ),
+        const SizedBox(height: 8),
+        Wrap(
+          spacing: 8,
+          runSpacing: 8,
+          children: const [
+            _Badge(label: 'ذهبي', color: Colors.amber, count: '5x', icon: Icons.emoji_events),
+            _Badge(label: 'فضي', color: Colors.grey, count: '3x', icon: Icons.emoji_events),
+            _Badge(label: 'برونزي', color: Colors.brown, count: '2x', icon: Icons.emoji_events),
+            _Badge(label: 'أسطوري', color: Colors.deepPurple, count: '1x', icon: Icons.emoji_events),
+            _Badge(label: 'بلاتيني', color: Colors.blueGrey, count: '1x', icon: Icons.emoji_events),
+          ],
+        ),
+      ],
+    );
+  }
+}
+
+/// Widget representing a single badge with color and count.
+class _Badge extends StatelessWidget {
+  /// Badge label.
+  final String label;
+
+  /// Background color for the badge.
+  final Color color;
+
+  /// Count string to display.
+  final String count;
+
+  /// Icon to show inside the badge.
+  final IconData icon;
+
+  /// Creates a const [_Badge].
+  const _Badge({
+    required this.label,
+    required this.color,
+    required this.count,
+    required this.icon,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 6),
+      decoration: BoxDecoration(
+        color: color,
+        borderRadius: BorderRadius.circular(20),
+      ),
+      child: Row(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          Icon(icon, size: 16, color: Colors.white),
+          const SizedBox(width: 4),
+          Text(
+            label,
+            style: const TextStyle(color: Colors.white),
+          ),
+          const SizedBox(width: 4),
+          Text(
+            count,
+            style: const TextStyle(color: Colors.white),
+          ),
+        ],
       ),
     );
   }

--- a/test/challenges_screen_test.dart
+++ b/test/challenges_screen_test.dart
@@ -184,5 +184,9 @@ void main() async {
     await tester.tap(find.widgetWithText(ElevatedButton, 'Manage Your Team'));
     await tester.pumpAndSettle();
     expect(find.text('Info'), findsWidgets);
+    // Verify that elements from the info tab exist.
+    expect(find.text('ريـمونتادا'), findsWidgets);
+    expect(find.byIcon(Icons.settings), findsOneWidget);
+    expect(find.text('الأوسمة والإنجازات'), findsOneWidget);
   });
 }


### PR DESCRIPTION
## Summary
- expand TeamDetailsPage info tab with three stacked widgets
- create private widgets for top bar, summary card and achievements
- test the new layout in challenges_screen_test

## Testing
- `flutter analyze`
- `flutter test`

------
https://chatgpt.com/codex/tasks/task_b_687e4157268c832c8f576a6e1ee48080