### PR TITLE
Handle missing team_id in team creation response

### DIFF
--- a/lib/features/challenges/presentation/screens/create_team_page.dart
+++ b/lib/features/challenges/presentation/screens/create_team_page.dart
@@ -13,6 +13,20 @@ import '../../../../core/config/key.dart';
 import '../../../../core/utils/utils.dart';
 import 'team_details_page.dart';
 
+/// Converts the dynamic value returned from the API into a valid team id.
+///
+/// Throws a [FormatException] when the id is missing or not numeric.
+int parseTeamId(dynamic teamId) {
+  if (teamId == null) {
+    throw const FormatException('team_id is missing from response');
+  }
+  final parsed = int.tryParse(teamId.toString());
+  if (parsed == null) {
+    throw FormatException('Invalid team_id format: $teamId');
+  }
+  return parsed;
+}
+
 /// Page allowing users to create a new team.
 class CreateTeamPage extends StatefulWidget {
   /// Default constructor for [CreateTeamPage].
@@ -92,6 +106,7 @@ class _CreateTeamPageState extends State<CreateTeamPage> {
     super.dispose();
   }
 
+
   /// Handles the multi-step create team flow as described in the docs.
   Future<void> _submitForm() async {
     if (_isSubmitting) return;
@@ -125,7 +140,8 @@ class _CreateTeamPageState extends State<CreateTeamPage> {
         return;
       }
 
-      final int teamId = data['data']['team_id'] as int;
+      final dynamic teamIdRaw = data['data']['team_id'];
+      final teamId = parseTeamId(teamIdRaw);
 
       // Step 2: optional subleader
       final subName = _assistantNameController.text.trim();

--- a/test/create_team_page_test.dart
+++ b/test/create_team_page_test.dart
@@ -3,6 +3,20 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:remontada/features/challenges/presentation/screens/create_team_page.dart';
 
 void main() {
+  group('parseTeamId', () {
+    test('returns integer when value is numeric', () {
+      expect(parseTeamId(5), 5);
+      expect(parseTeamId('10'), 10);
+    });
+
+    test('throws FormatException when null', () {
+      expect(() => parseTeamId(null), throwsFormatException);
+    });
+
+    test('throws FormatException on invalid format', () {
+      expect(() => parseTeamId('abc'), throwsFormatException);
+    });
+  });
   testWidgets('CreateTeamPage layout displays all sections', (tester) async {
     await tester.pumpWidget(const MaterialApp(home: CreateTeamPage()));
     await tester.pumpAndSettle();


### PR DESCRIPTION
## Summary
- ensure team_id parsing is safe when creating a team
- expose `parseTeamId` helper
- cover parsing logic with unit tests

## Testing
- `pytest -q` *(fails: no tests found)*
- `flutter test` *(fails: `flutter` not installed)*

------
https://chatgpt.com/codex/tasks/task_b_687fc7f47e30832ca0d5eb54457b432e