### PR TITLE
Add dynamic team info

### DIFF
--- a/test/find_member_test.dart
+++ b/test/find_member_test.dart
@@ -1,0 +1,23 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:remontada/features/challenges/presentation/screens/team_details_page.dart';
+
+void main() {
+  group('find member', () {
+    test('returns matching user when role exists', () {
+      final users = [
+        {'name': 'A', 'mobile': '1', 'role': 'leader'},
+        {'name': 'B', 'mobile': '2', 'role': 'member'},
+      ];
+      final res = _findMemberByRole(users, 'leader');
+      expect(res?['name'], 'A');
+    });
+
+    test('returns null when role not found', () {
+      final users = [
+        {'name': 'A', 'mobile': '1', 'role': 'member'},
+      ];
+      final res = _findMemberByRole(users, 'leader');
+      expect(res, isNull);
+    });
+  });
+}

--- a/test/obfuscate_phone_test.dart
+++ b/test/obfuscate_phone_test.dart
@@ -1,0 +1,14 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:remontada/features/challenges/presentation/screens/team_details_page.dart';
+
+void main() {
+  group('obfuscatePhone', () {
+    test('hides middle digits when length > 2', () {
+      expect(obfuscatePhone('0123456789'), '0........9');
+    });
+
+    test('returns original when length <= 2', () {
+      expect(obfuscatePhone('05'), '05');
+    });
+  });
+}


### PR DESCRIPTION
## Summary
- fetch and display team name, logo, bio, and members count in Team Details page
- show leader and assistant names & phones with obfuscation
- provide helper `obfuscatePhone`
- update tabs to pass team data through widgets
- add unit test for phone obfuscation
- parse leader and assistant from API users list
- add test for helper to find members by role

## Testing
- `flake8`
- `pytest`
- `flutter test test/obfuscate_phone_test.dart test/find_member_test.dart` *(fails: No tests ran)*

------
https://chatgpt.com/codex/tasks/task_b_687fd6bc3060832cae3f2d368f34fc05