### PR TITLE
Add create team banner for teamless users

### DIFF
--- a/lib/features/challenges/presentation/screens/challenges_screen.dart
+++ b/lib/features/challenges/presentation/screens/challenges_screen.dart
@@ -790,6 +790,69 @@ class _ChallengesScreenState extends State<ChallengesScreen>
     );
   }
 
+  /// Builds a banner prompting users without a team to create one.
+  ///
+  /// Displays an icon, a short message and a button that navigates to
+  /// [CreateTeamPage] when pressed.
+  Widget _buildCreateTeamBanner() {
+    const darkBlue = Color(0xFF23425F);
+    return Directionality(
+      textDirection: TextDirection.rtl,
+      child: Container(
+        padding: const EdgeInsets.symmetric(horizontal: 16.0, vertical: 8.0),
+        color: const Color(0xFFF2F2F2),
+        child: Row(
+          mainAxisAlignment: MainAxisAlignment.spaceBetween,
+          crossAxisAlignment: CrossAxisAlignment.center,
+          children: [
+            CircleAvatar(
+              backgroundColor: darkBlue,
+              child: const Icon(Icons.group, color: Colors.white),
+            ),
+            Expanded(
+              child: Center(
+                child: Text(
+                  LocaleKeys.challenge_create_team.tr(),
+                  style: const TextStyle(
+                    color: darkBlue,
+                    fontWeight: FontWeight.bold,
+                  ),
+                ),
+              ),
+            ),
+            SizedBox(
+              height: 36,
+              child: ElevatedButton(
+                onPressed: () {
+                  Navigator.push(
+                    context,
+                    MaterialPageRoute(
+                        builder: (_) => const CreateTeamPage()),
+                  );
+                },
+                style: ElevatedButton.styleFrom(
+                  backgroundColor: darkBlue,
+                  minimumSize: const Size(120, 36),
+                  padding: const EdgeInsets.symmetric(horizontal: 12),
+                  shape: RoundedRectangleBorder(
+                    borderRadius: BorderRadius.circular(8),
+                  ),
+                ),
+                child: Text(
+                  LocaleKeys.challenge_create_team.tr(),
+                  style: const TextStyle(
+                    color: Colors.white,
+                    fontWeight: FontWeight.bold,
+                  ),
+                ),
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+
   @override
   Widget build(BuildContext context) {
     const darkBlue = Color(0xFF23425F);
@@ -850,7 +913,7 @@ class _ChallengesScreenState extends State<ChallengesScreen>
               ),
               const SizedBox(height: 16),
               _buildCarousel(),
-              if (_hasTeam ?? false) _manageTeamRow(),
+              (_hasTeam ?? false) ? _manageTeamRow() : _buildCreateTeamBanner(),
               18.ph,
               Directionality(
                 textDirection: TextDirection.rtl,

--- a/test/challenges_screen_test.dart
+++ b/test/challenges_screen_test.dart
@@ -18,7 +18,7 @@ void main() async {
       tester.binding.window.clearDevicePixelRatioTestValue();
     });
     await tester.pumpWidget(
-        const MaterialApp(home: ChallengesScreen(hasTeam: true)));
+        const MaterialApp(home: ChallengesScreen(hasTeam: false)));
     await tester.pumpAndSettle();
     expect(find.byIcon(Icons.group), findsOneWidget);
     expect(find.byIcon(Icons.more_horiz), findsOneWidget);
@@ -72,6 +72,8 @@ void main() async {
     await tester.pumpAndSettle();
     expect(find.widgetWithText(ElevatedButton, 'manage_your_team'), findsNothing);
     expect(find.text('challenge_create_challenge'), findsNothing);
+    expect(find.widgetWithText(ElevatedButton, 'challenge_create_team'),
+        findsOneWidget);
   });
 
   testWidgets('first tab shows challenge cards', (tester) async {
@@ -174,9 +176,10 @@ void main() async {
       tester.binding.window.clearDevicePixelRatioTestValue();
     });
     await tester.pumpWidget(
-        const MaterialApp(home: ChallengesScreen(hasTeam: true)));
+        const MaterialApp(home: ChallengesScreen(hasTeam: false)));
     await tester.pumpAndSettle();
-    await tester.tap(find.byIcon(Icons.group));
+    await tester.tap(
+        find.widgetWithText(ElevatedButton, 'challenge_create_team'));
     await tester.pumpAndSettle();
     expect(find.text('create_team_title'), findsOneWidget);
   });


### PR DESCRIPTION
## Summary
- add banner prompting users to create a team
- show create-team banner when user has no team
- adjust tests for new create-team flow

## Testing
- `flutter test` *(fails: command not found: flutter)*
- `dart format lib/features/challenges/presentation/screens/challenges_screen.dart test/challenges_screen_test.dart` *(fails: command not found: dart)*

------
https://chatgpt.com/codex/tasks/task_b_68a074a2e7a0832bb85134da2b757c56