### PR TITLE
Hide join challenge card when user lacks team

### DIFF
--- a/lib/features/challenges/presentation/screens/challenges_screen.dart
+++ b/lib/features/challenges/presentation/screens/challenges_screen.dart
@@ -393,6 +393,18 @@ class _ChallengesScreenState extends State<ChallengesScreen>
     );
   }
 
+  /// Displays a placeholder message when the player does not belong to a team.
+  Widget _noTeamPlaceholder() {
+    return const Padding(
+      padding: EdgeInsets.symmetric(vertical: 24),
+      child: Text(
+        'You need a team to participate in challenges',
+        textAlign: TextAlign.center,
+        style: TextStyle(color: Colors.grey),
+      ),
+    );
+  }
+
   /// Builds a button allowing a user to initiate a new challenge.
   Widget _createChallengeButton() {
     const darkBlue = Color(0xFF23425F);
@@ -958,8 +970,13 @@ class _ChallengesScreenState extends State<ChallengesScreen>
                           ],
                           _completedChallengeCard(),
                           const SizedBox(height: 12),
-                          _joinChallengeCard(),
-                          const SizedBox(height: 12),
+                          if (_hasTeam ?? false) ...[
+                            _joinChallengeCard(),
+                            const SizedBox(height: 12),
+                          ] else ...[
+                            _noTeamPlaceholder(),
+                            const SizedBox(height: 12),
+                          ],
                           _howChallengesWorkCard(),
                         ],
                       ),


### PR DESCRIPTION
## Summary
- show join challenge card only for users with a team
- add placeholder message when user has no team

## Testing
- `dart format lib/features/challenges/presentation/screens/challenges_screen.dart` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_68a07a176620832b88016b677f4caa2c