### PR TITLE
Fix location permission request flow before acquiring position

### DIFF
--- a/lib/features/splash/cubit/splash_cubit.dart
+++ b/lib/features/splash/cubit/splash_cubit.dart
@@ -86,36 +86,20 @@ class SplashCubit extends Cubit<SplashStates> {
 
   Future<Position?> getLocation() async {
     try {
-      PermissionStatus status = await Permission.location.status;
-      await Permission.location.request;
-      // Permission.location.onDeniedCallback(() async {
-      //   await Permission.location.request();
-      // });
-      if (status.isDenied == true) {
-        await Permission.location.request();
+      final status = await Permission.location.request();
 
-        // showLocationPermissionDialog(
-        //   context,
-        // );
-        emit(LocationDeniedstate());
-      } else if (status.isPermanentlyDenied == true) {
-        // await Permission.location.request();
-        // showLocationPermissionDialog(
-        //   context,
-        // );
-        emit(LocationDeniedstate());
-      } else if (status.isGranted == true) {
+      if (status.isGranted) {
         return await Geolocator.getCurrentPosition(
           desiredAccuracy: LocationAccuracy.high,
         );
+      } else if (status.isDenied || status.isPermanentlyDenied) {
+        emit(LocationDeniedstate());
+        return null;
       }
     } catch (e) {
       log(e.toString(), name: "error");
     }
-    // print("status $status");
-    return await Geolocator.getCurrentPosition(
-      desiredAccuracy: LocationAccuracy.high,
-    );
+    return null;
   }
 
   Future<void> getPostion() async {


### PR DESCRIPTION
## Summary
- request location permission correctly and evaluate status
- call `Geolocator.getCurrentPosition` only when permission granted

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_68a649056b70832ba705e1d88fac48c4