### PR TITLE
fix: avoid duplicate Firebase initialization

### DIFF
--- a/lib/core/utils/firebase_message.dart
+++ b/lib/core/utils/firebase_message.dart
@@ -14,9 +14,11 @@ class FBMessging {
   @pragma('vm:entry-point')
   static Future<void> firebaseMessagingBackgroundHandler(
       RemoteMessage message) async {
-    await Firebase.initializeApp(
-      options: DefaultFirebaseOptions.currentPlatform,
-    );
+    if (Firebase.apps.isEmpty) {
+      await Firebase.initializeApp(
+        options: DefaultFirebaseOptions.currentPlatform,
+      );
+    }
     await FirebaseMessaging.instance
         .setForegroundNotificationPresentationOptions(
       alert: true,
@@ -276,9 +278,11 @@ class FBMessging {
   // }
 
   static getToken() async {
-    await Firebase.initializeApp(
-      options: DefaultFirebaseOptions.currentPlatform,
-    );
+    if (Firebase.apps.isEmpty) {
+      await Firebase.initializeApp(
+        options: DefaultFirebaseOptions.currentPlatform,
+      );
+    }
     await Future.delayed(const Duration(seconds: 1));
     await messaging.getToken().then((tokenFcm) {
       print(tokenFcm);

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -24,9 +24,11 @@ Future<void> main() async {
   WidgetsFlutterBinding.ensureInitialized();
   await EasyLocalization.ensureInitialized();
 
-  await Firebase.initializeApp(
-    options: DefaultFirebaseOptions.currentPlatform,
-  );
+  if (Firebase.apps.isEmpty) {
+    await Firebase.initializeApp(
+      options: DefaultFirebaseOptions.currentPlatform,
+    );
+  }
 
   FirebaseMessaging.onBackgroundMessage(
     FBMessging.firebaseMessagingBackgroundHandler,


### PR DESCRIPTION
## Summary
- guard Firebase initialization to prevent duplicate default app errors

## Testing
- `dart format lib/main.dart lib/core/utils/firebase_message.dart` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_68a75ffc40cc832b956bd411bc83055e