### PR TITLE
Add challenge match creation flow with supervisor access

### DIFF
--- a/assets/translations/ar-EG.json
+++ b/assets/translations/ar-EG.json
@@ -347,5 +347,21 @@
   "have_an_account": "هل لديك حساب؟",
   "signUp": "اشتراك",
   "confirm_password": "تأكيد كلمة المرور",
-  "change_password": "تغيير كلمة المرور"
+  "change_password": "تغيير كلمة المرور",
+  "create_match": {
+    "title": "إنشاء مباراة",
+    "subscribers_qty": "عدد المشتركين",
+    "date": "التاريخ",
+    "time": "الوقت",
+    "durations": "المدة",
+    "durations_text": "وصف المدة",
+    "details": "التفاصيل",
+    "amount": "المبلغ",
+    "type": "نوع المباراة",
+    "challenge": "تحدي",
+    "friendly": "ودي",
+    "submit": "إنشاء المباراة",
+    "success": "تم اضافة الطلب بنجاح",
+    "error": "فشل في اضافة المباراة"
+  }
 }

--- a/assets/translations/en-US.json
+++ b/assets/translations/en-US.json
@@ -347,5 +347,21 @@
   },
   "SubscribeNow": "Subscribe now",
   "Subscribedone": "Your subscription has been confirmed",
-  "Subscribedone_des": "Your subscription and joining the match successfully confirmed"
+  "Subscribedone_des": "Your subscription and joining the match successfully confirmed",
+  "create_match": {
+    "title": "Create Match",
+    "subscribers_qty": "Subscribers quantity",
+    "date": "Date",
+    "time": "Time",
+    "durations": "Duration",
+    "durations_text": "Duration description",
+    "details": "Details",
+    "amount": "Amount",
+    "type": "Match type",
+    "challenge": "Challenge",
+    "friendly": "Friendly",
+    "submit": "Create Match",
+    "success": "Match request added successfully",
+    "error": "Failed to add match"
+  }
 }

--- a/lib/core/Router/Router.dart
+++ b/lib/core/Router/Router.dart
@@ -6,8 +6,11 @@ import 'package:remontada/features/home/presentation/screens/webview.dart';
 import 'package:remontada/features/layout/presentation/screens/layout_screen.dart';
 import 'package:remontada/features/matchdetails/presentaion/screens/matchDetails_screen.dart';
 import 'package:remontada/features/more/domain/contact_request.dart';
-import 'package:remontada/features/my_matches/presentation/screens/create_match_screen.dart';
+import 'package:remontada/features/my_matches/presentation/screens/create_match_screen.dart'
+    as my_matches;
 import 'package:remontada/features/challenges/presentation/screens/challenges_screen.dart';
+import 'package:remontada/features/challenges/presentation/screens/create_match_screen.dart'
+    as challenges;
 import 'package:remontada/features/player_details/presentation/screens/player_details.dart';
 import 'package:remontada/features/profile/presentation/screens/edit_profile.screen.dart';
 import 'package:remontada/features/splash/cubit/splash_cubit.dart';
@@ -50,6 +53,7 @@ class Routes {
   static const String contactScreen = "/contactScreen";
   static const String webPage = "/webPage";
   static const String CreateMatchScreen = "/CreateMatchScreen";
+  static const String createMatch = "/createMatch";
   static const String PlayersScreenSupervisor = "/PlayersScreenSupervisor";
   static const String challengesScreen = "/ChallengesScreen";
   static const String UpdateAppScreen = "/UpdateAppScreen";
@@ -211,10 +215,16 @@ class RouteGenerator {
         return CupertinoPageRoute(
           settings: routeSettings,
           builder: (_) {
-            return CreateMatchScreen(
+            return my_matches.CreateMatchScreen(
               id: routeSettings.arguments as String?,
-              // uri: routeSettings.arguments as String,
             );
+          },
+        );
+      case Routes.createMatch:
+        return CupertinoPageRoute(
+          settings: routeSettings,
+          builder: (_) {
+            return const challenges.CreateMatchScreen();
           },
         );
       case Routes.PlayersScreenSupervisor:

--- a/lib/core/app_strings/locale_keys.dart
+++ b/lib/core/app_strings/locale_keys.dart
@@ -337,4 +337,18 @@ abstract class LocaleKeys {
   // Challenge keys
   static const String challenge_no_matches_available = 'challenge_no_matches_available';
   static const String challenge_error_loading_matches = 'challenge_error_loading_matches';
+  static const create_match_title = 'create_match.title';
+  static const create_match_subscribers_qty = 'create_match.subscribers_qty';
+  static const create_match_date = 'create_match.date';
+  static const create_match_time = 'create_match.time';
+  static const create_match_durations = 'create_match.durations';
+  static const create_match_durations_text = 'create_match.durations_text';
+  static const create_match_details = 'create_match.details';
+  static const create_match_amount = 'create_match.amount';
+  static const create_match_type = 'create_match.type';
+  static const create_match_challenge = 'create_match.challenge';
+  static const create_match_friendly = 'create_match.friendly';
+  static const create_match_submit = 'create_match.submit';
+  static const create_match_success = 'create_match.success';
+  static const create_match_error = 'create_match.error';
 }

--- a/lib/features/challenges/data/challenges_repository_impl.dart
+++ b/lib/features/challenges/data/challenges_repository_impl.dart
@@ -8,6 +8,7 @@ import '../domain/model/create_challenge_response.dart';
 import '../domain/model/user_team_model.dart';
 import '../domain/model/match_model.dart';
 import '../domain/repository/challenges_repository.dart';
+import '../domain/request/create_match_request.dart';
 
 class ChallengesRepositoryImpl implements ChallengesRepository {
   @override
@@ -163,5 +164,19 @@ class ChallengesRepositoryImpl implements ChallengesRepository {
     
     // If all endpoints fail, throw a generic error
     throw Exception('No matches available at the moment. Please check back later or contact support if the issue persists.');
+  }
+
+  @override
+  Future<http.Response> createMatch(CreateMatchRequest request) async {
+    final response = await http.post(
+      Uri.parse('${ConstKeys.baseUrl}/matches'),
+      headers: {
+        'Accept': 'application/json',
+        'Content-Type': 'application/json',
+        'Authorization': 'Bearer ${Utils.token}',
+      },
+      body: jsonEncode(request.toMap()),
+    );
+    return response;
   }
 }

--- a/lib/features/challenges/domain/repository/challenges_repository.dart
+++ b/lib/features/challenges/domain/repository/challenges_repository.dart
@@ -1,12 +1,16 @@
+import 'package:http/http.dart' as http;
+
 import '../model/challenge_overview_model.dart';
 import '../model/create_challenge_request.dart';
 import '../model/create_challenge_response.dart';
 import '../model/user_team_model.dart';
 import '../model/match_model.dart';
+import '../request/create_match_request.dart';
 
 abstract class ChallengesRepository {
   Future<List<ChallengeOverviewModel>> getChallengesOverview();
   Future<CreateChallengeResponse> createChallenge(CreateChallengeRequest request);
   Future<List<UserTeamModel>> getUserTeams();
   Future<List<MatchModel>> getAvailableMatches();
+  Future<http.Response> createMatch(CreateMatchRequest request);
 }

--- a/lib/features/challenges/domain/request/create_match_request.dart
+++ b/lib/features/challenges/domain/request/create_match_request.dart
@@ -1,0 +1,40 @@
+class CreateMatchRequest {
+  final String playgroundId;
+  final String supervisorId;
+  final String subscribersQty;
+  final String date;
+  final String startTime;
+  final String durations;
+  final String durationsText;
+  final String details;
+  final String amount;
+  final String type;
+
+  CreateMatchRequest({
+    required this.playgroundId,
+    required this.supervisorId,
+    required this.subscribersQty,
+    required this.date,
+    required this.startTime,
+    required this.durations,
+    required this.durationsText,
+    required this.details,
+    required this.amount,
+    required this.type,
+  });
+
+  Map<String, dynamic> toMap() {
+    return {
+      'playground_id': playgroundId,
+      'supervisor_id': supervisorId,
+      'subscribers_qty': subscribersQty,
+      'date': date,
+      'start_time': startTime,
+      'durations': durations,
+      'durations_text': durationsText,
+      'details': details,
+      'amount': amount,
+      'type': type,
+    };
+  }
+}

--- a/lib/features/challenges/presentation/screens/challenges_screen.dart
+++ b/lib/features/challenges/presentation/screens/challenges_screen.dart
@@ -14,6 +14,7 @@ import 'dart:convert';
 import 'package:http/http.dart' as http;
 import '../../../../core/config/key.dart';
 import '../../../../core/utils/utils.dart';
+import '../../../../core/Router/Router.dart';
 import '../../domain/model/challenge_overview_model.dart';
 import '../../data/challenges_repository_impl.dart';
 
@@ -885,6 +886,14 @@ class _ChallengesScreenState extends State<ChallengesScreen>
   Widget build(BuildContext context) {
     const darkBlue = Color(0xFF23425F);
     return Scaffold(
+      floatingActionButton: Utils.isSuperVisor == true
+          ? FloatingActionButton(
+              onPressed: () {
+                Navigator.pushNamed(context, Routes.createMatch);
+              },
+              child: const Icon(Icons.add),
+            )
+          : null,
       body: SafeArea(
         child: Padding(
           padding: const EdgeInsets.all(16),

--- a/lib/features/challenges/presentation/screens/create_match_screen.dart
+++ b/lib/features/challenges/presentation/screens/create_match_screen.dart
@@ -1,0 +1,210 @@
+import 'dart:convert';
+
+import 'package:easy_localization/easy_localization.dart';
+import 'package:flutter/material.dart';
+
+import '../../../../core/app_strings/locale_keys.dart';
+import '../../../../core/utils/utils.dart';
+import '../../data/challenges_repository_impl.dart';
+import '../../domain/request/create_match_request.dart';
+
+class CreateMatchScreen extends StatefulWidget {
+  const CreateMatchScreen({super.key});
+
+  @override
+  State<CreateMatchScreen> createState() => _CreateMatchScreenState();
+}
+
+class _CreateMatchScreenState extends State<CreateMatchScreen> {
+  final _formKey = GlobalKey<FormState>();
+  final _subscribersController = TextEditingController();
+  final _dateController = TextEditingController();
+  final _timeController = TextEditingController();
+  final _durationController = TextEditingController();
+  final _durationTextController = TextEditingController();
+  final _detailsController = TextEditingController();
+  final _amountController = TextEditingController();
+  String? _type;
+
+  @override
+  void dispose() {
+    _subscribersController.dispose();
+    _dateController.dispose();
+    _timeController.dispose();
+    _durationController.dispose();
+    _durationTextController.dispose();
+    _detailsController.dispose();
+    _amountController.dispose();
+    super.dispose();
+  }
+
+  Future<void> _pickDate() async {
+    final now = DateTime.now();
+    final picked = await showDatePicker(
+      context: context,
+      firstDate: now,
+      lastDate: DateTime(now.year + 5),
+      initialDate: now,
+    );
+    if (picked != null) {
+      _dateController.text = DateFormat('yyyy-MM-dd').format(picked);
+    }
+  }
+
+  Future<void> _pickTime() async {
+    final picked = await showTimePicker(
+      context: context,
+      initialTime: TimeOfDay.now(),
+    );
+    if (picked != null) {
+      _timeController.text = picked.format(context);
+    }
+  }
+
+  Future<void> _submit() async {
+    if (!_formKey.currentState!.validate()) return;
+    final request = CreateMatchRequest(
+      playgroundId: '11',
+      supervisorId: Utils.user.user?.id?.toString() ?? '',
+      subscribersQty: _subscribersController.text,
+      date: _dateController.text,
+      startTime: _timeController.text,
+      durations: _durationController.text,
+      durationsText: _durationTextController.text,
+      details: _detailsController.text,
+      amount: _amountController.text,
+      type: _type ?? '',
+    );
+    try {
+      final repo = ChallengesRepositoryImpl();
+      final res = await repo.createMatch(request);
+      final data = jsonDecode(res.body) as Map<String, dynamic>;
+      if (data['status'] == true) {
+        if (!mounted) return;
+        ScaffoldMessenger.of(context).showSnackBar(
+          SnackBar(
+            backgroundColor: Colors.green,
+            content: Text(LocaleKeys.create_match_success.tr()),
+          ),
+        );
+        Navigator.pop(context);
+      } else {
+        _showError();
+      }
+    } catch (_) {
+      _showError();
+    }
+  }
+
+  void _showError() {
+    if (!mounted) return;
+    ScaffoldMessenger.of(context).showSnackBar(
+      SnackBar(
+        backgroundColor: Colors.red,
+        content: Text(LocaleKeys.create_match_error.tr()),
+      ),
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        title: Text(LocaleKeys.create_match_title.tr()),
+      ),
+      body: Padding(
+        padding: const EdgeInsets.all(16),
+        child: Form(
+          key: _formKey,
+          child: SingleChildScrollView(
+            child: Column(
+              children: [
+                TextFormField(
+                  controller: _subscribersController,
+                  keyboardType: TextInputType.number,
+                  decoration: InputDecoration(
+                    labelText: LocaleKeys.create_match_subscribers_qty.tr(),
+                  ),
+                  validator: Utils.valid.defaultValidation,
+                ),
+                TextFormField(
+                  controller: _dateController,
+                  readOnly: true,
+                  decoration: InputDecoration(
+                    labelText: LocaleKeys.create_match_date.tr(),
+                  ),
+                  onTap: _pickDate,
+                  validator: Utils.valid.defaultValidation,
+                ),
+                TextFormField(
+                  controller: _timeController,
+                  readOnly: true,
+                  decoration: InputDecoration(
+                    labelText: LocaleKeys.create_match_time.tr(),
+                  ),
+                  onTap: _pickTime,
+                  validator: Utils.valid.defaultValidation,
+                ),
+                TextFormField(
+                  controller: _durationController,
+                  keyboardType: TextInputType.number,
+                  decoration: InputDecoration(
+                    labelText: LocaleKeys.create_match_durations.tr(),
+                  ),
+                  validator: Utils.valid.defaultValidation,
+                ),
+                TextFormField(
+                  controller: _durationTextController,
+                  decoration: InputDecoration(
+                    labelText: LocaleKeys.create_match_durations_text.tr(),
+                  ),
+                  validator: Utils.valid.defaultValidation,
+                ),
+                TextFormField(
+                  controller: _detailsController,
+                  decoration: InputDecoration(
+                    labelText: LocaleKeys.create_match_details.tr(),
+                  ),
+                  validator: Utils.valid.defaultValidation,
+                ),
+                TextFormField(
+                  controller: _amountController,
+                  keyboardType: TextInputType.number,
+                  decoration: InputDecoration(
+                    labelText: LocaleKeys.create_match_amount.tr(),
+                  ),
+                  validator: Utils.valid.defaultValidation,
+                ),
+                DropdownButtonFormField<String>(
+                  value: _type,
+                  decoration: InputDecoration(
+                    labelText: LocaleKeys.create_match_type.tr(),
+                  ),
+                  items: [
+                    DropdownMenuItem(
+                      value: 'challenge',
+                      child: Text(LocaleKeys.create_match_challenge.tr()),
+                    ),
+                    DropdownMenuItem(
+                      value: 'friendly',
+                      child: Text(LocaleKeys.create_match_friendly.tr()),
+                    ),
+                  ],
+                  onChanged: (val) => setState(() => _type = val),
+                  validator: (val) => val == null
+                      ? LocaleKeys.valid_requiredField.tr()
+                      : null,
+                ),
+                const SizedBox(height: 24),
+                ElevatedButton(
+                  onPressed: _submit,
+                  child: Text(LocaleKeys.create_match_submit.tr()),
+                ),
+              ],
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}


### PR DESCRIPTION
## Summary
- add `Routes.createMatch` and wire it to new challenge match form
- show FAB on challenges screen for supervisors to create a match
- implement localized create match form, request model and repository call

## Testing
- `flutter pub run easy_localization:generate -S assets/translations -O lib/core/app_strings -o locale_keys.dart -f keys` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_68ab6f5abb58832b91f7891a227289d9