### PR TITLE
fix: update supervisor flag handling

### DIFF
--- a/lib/core/data_source/hive_helper.dart
+++ b/lib/core/data_source/hive_helper.dart
@@ -58,7 +58,11 @@ class DataManager {
       final user = (Map<String, dynamic>.from(userData.get(USER)));
 
       Utils.token = user['access_token'];
-      Utils.isSuperVisor = user['type'] == "supervisor";
+      Utils.isSuperVisor = user['type'] == 'supervisor';
+      final context = Utils.navigatorKey().currentContext;
+      if (context != null) {
+        Utils.rebuildAllChildren(context);
+      }
       log(Utils.token);
 
       // Utils.userModel = UserModel.fromJson(Map<String, dynamic>.from(user));

--- a/lib/core/utils/utils.dart
+++ b/lib/core/utils/utils.dart
@@ -36,16 +36,18 @@ class Utils {
   static DataManager get dataManager => locator<DataManager>();
 
   static saveUserInHive(Map<String, dynamic> response) async {
-    // user = User.fromMap(response);
-
     user = User.fromMap(response);
     token = user.token ?? '';
-    isSuperVisor = user.user?.type == "supervisor";
+    isSuperVisor = response['type'] == 'supervisor';
     FBMessging.subscripeAllUsers();
     await user.type == "client"
         ? FBMessging.subscripeAllclients()
         : FBMessging.subscripeAllcouches();
     await Utils.dataManager.saveUser(Map<String, dynamic>.from(response));
+    final context = navigatorKey().currentContext;
+    if (context != null) {
+      rebuildAllChildren(context);
+    }
   }
 
   static deleteUserData() async {

--- a/lib/features/challenges/presentation/screens/challenges_screen.dart
+++ b/lib/features/challenges/presentation/screens/challenges_screen.dart
@@ -886,7 +886,7 @@ class _ChallengesScreenState extends State<ChallengesScreen>
   Widget build(BuildContext context) {
     const darkBlue = Color(0xFF23425F);
     return Scaffold(
-      floatingActionButton: Utils.isSuperVisor == true
+      floatingActionButton: (Utils.isSuperVisor ?? false)
           ? FloatingActionButton(
               onPressed: () {
                 Navigator.pushNamed(context, Routes.createMatch);


### PR DESCRIPTION
## Summary
- track supervisor role directly from login and persistence payloads
- refresh widget tree after session changes
- guard Challenges FAB against null supervisor flag

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_68ab736ffd54832b9da8f00a6c87fdc9